### PR TITLE
add explicit ovx=32 to cadzow_denoiser calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.6.0] - UNRELEASED
 
 ### Changed
-- Cadzow denoising updated to `cadzow_denoiser` (replaces deprecated `cadzow_np1`): uses batched SVD, geometry-agnostic; `rank=5`, `fmax=125`, `nswx=64`, `gap_threshold=2.0`, `ppca_k=2.0`
+- Cadzow denoising updated to `cadzow_denoiser` (replaces deprecated `cadzow_np1`): uses batched SVD, geometry-agnostic; `rank=5`, `fmax=125`, `nswx=64`, `ovx=32`, `gap_threshold=2.0`, `ppca_k=2.0`
 - Bumped `ibl-neuropixel` requirement to `>=1.11.0`
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [0.6.0] - UNRELEASED
 
+### Changed
+- Cadzow denoising updated to `cadzow_denoiser` (replaces deprecated `cadzow_np1`): uses batched SVD, geometry-agnostic; `rank=5`, `fmax=125`, `nswx=64`, `gap_threshold=2.0`, `ppca_k=2.0`
+- Bumped `ibl-neuropixel` requirement to `>=1.11.0`
+
 ### Added
 **Cells Features***
 - Unit tests for `compute_burstiness_and_memory` in `tests/test_cells.py`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "h5py==3.15.1", #Some dartsort error arises in the unit tests, if I don't fix this.
     "hdbscan>=0.8.40",
     "ibllib>=3.3.1",
-    "ibl-neuropixel>=1.10.0",
+    "ibl-neuropixel>=1.11.0",
     "linear-operator>=0.6",
     "mock>=5.2.0",
     "opt-einsum>=3.4.0",

--- a/src/ephysatlas/features.py
+++ b/src/ephysatlas/features.py
@@ -1066,8 +1066,9 @@ def csd(data, fs, geometry, bands=None, decimate=10):
         before computing the spectral features.
     """
     data_rs = scipy.signal.decimate(data, decimate, axis=1, ftype="fir")
-    data_rs = ibldsp.cadzow.cadzow_np1(
-        data_rs, rank=2, fs=fs / decimate, niter=1, fmax=90, h=geometry
+    data_rs = ibldsp.cadzow.cadzow_denoiser(
+        data_rs, rank=5, fs=fs / decimate, niter=1, fmax=125,
+        nswx=64, gap_threshold=2.0, ppca_k=2.0, h=geometry
     )
     # Calculate the CSD features
     data_rs_diff2 = ibldsp.voltage.current_source_density(data_rs, h=geometry, n=2)

--- a/src/ephysatlas/features.py
+++ b/src/ephysatlas/features.py
@@ -1067,8 +1067,15 @@ def csd(data, fs, geometry, bands=None, decimate=10):
     """
     data_rs = scipy.signal.decimate(data, decimate, axis=1, ftype="fir")
     data_rs = ibldsp.cadzow.cadzow_denoiser(
-        data_rs, rank=5, fs=fs / decimate, niter=1, fmax=125,
-        nswx=64, gap_threshold=2.0, ppca_k=2.0, h=geometry
+        data_rs,
+        rank=5,
+        fs=fs / decimate,
+        niter=1,
+        fmax=125,
+        nswx=64,
+        gap_threshold=2.0,
+        ppca_k=2.0,
+        h=geometry,
     )
     # Calculate the CSD features
     data_rs_diff2 = ibldsp.voltage.current_source_density(data_rs, h=geometry, n=2)

--- a/src/ephysatlas/features.py
+++ b/src/ephysatlas/features.py
@@ -1073,6 +1073,7 @@ def csd(data, fs, geometry, bands=None, decimate=10):
         niter=1,
         fmax=125,
         nswx=64,
+        ovx=32,
         gap_threshold=2.0,
         ppca_k=2.0,
         h=geometry,

--- a/src/ephysatlas/reveal.py
+++ b/src/ephysatlas/reveal.py
@@ -560,8 +560,14 @@ class AtlasReveal:
         )
         csd = scipy.signal.decimate(preproc, q=5, zero_phase=True)
         csd = ibldsp.cadzow.cadzow_denoiser(
-            csd, rank=5, fs=self.sr_lf.fs / 5, fmax=125,
-            nswx=64, gap_threshold=2.0, ppca_k=2.0, h=self.sr_lf.geometry
+            csd,
+            rank=5,
+            fs=self.sr_lf.fs / 5,
+            fmax=125,
+            nswx=64,
+            gap_threshold=2.0,
+            ppca_k=2.0,
+            h=self.sr_lf.geometry,
         )
         csd = ibldsp.voltage.current_source_density(csd, h=self.sr_lf.geometry)
 

--- a/src/ephysatlas/reveal.py
+++ b/src/ephysatlas/reveal.py
@@ -565,6 +565,7 @@ class AtlasReveal:
             fs=self.sr_lf.fs / 5,
             fmax=125,
             nswx=64,
+            ovx=32,
             gap_threshold=2.0,
             ppca_k=2.0,
             h=self.sr_lf.geometry,

--- a/src/ephysatlas/reveal.py
+++ b/src/ephysatlas/reveal.py
@@ -559,8 +559,9 @@ class AtlasReveal:
             butt, fs=self.sr_lf.fs, channel_labels=channel_labels, k_filter=None
         )
         csd = scipy.signal.decimate(preproc, q=5, zero_phase=True)
-        csd = ibldsp.cadzow.cadzow_np1(
-            csd, fs=self.sr_lf.fs / 5, fmax=200, rank=4, h=self.sr_lf.geometry
+        csd = ibldsp.cadzow.cadzow_denoiser(
+            csd, rank=5, fs=self.sr_lf.fs / 5, fmax=125,
+            nswx=64, gap_threshold=2.0, ppca_k=2.0, h=self.sr_lf.geometry
         )
         csd = ibldsp.voltage.current_source_density(csd, h=self.sr_lf.geometry)
 


### PR DESCRIPTION
## Summary
- Add `ovx=32` (50% overlap) explicitly to both `cadzow_denoiser` call sites in `features.py` and `reveal.py`
- Update CHANGELOG for 0.6.0 to document the `ovx=32` parameter

The previous calls relied on the `ibldsp` default `ovx=16`, which caused 7 visible CSD stripes due to insufficient spatial-window overlap. The fix is explicit in ibl-neuropixel >= 1.11.1 but adding it here makes the intent clear regardless of the installed version.

## Test plan
- [ ] Verify CSD figures no longer show horizontal stripes
- [ ] CI passes