### PR TITLE
Add loading of merged LFP-compressed (lfpack) archives from S3

### DIFF
--- a/docs/source/how-to/index.rst
+++ b/docs/source/how-to/index.rst
@@ -12,6 +12,7 @@ Getting Started
    s3-architecture
    load-channel-features
    load-cells-features
+   load-lfp-features
    basic-feature-extraction
 
 Overview

--- a/docs/source/how-to/load-lfp-features.rst
+++ b/docs/source/how-to/load-lfp-features.rst
@@ -1,0 +1,69 @@
+Load LFP Features
+==================
+
+This guide covers downloading and loading the **full-recording compressed LFP**
+archives produced by `lfpack <https://github.com/int-brain-lab/lfpack>`_: lossy
+HDF5 encodings (>100× compression, RMSE < 25 µV) of the entire LFP trace for
+every insertion, at two compression levels.
+
+S3 Layout
+---------
+
+.. code-block:: text
+
+    aggregates/atlas/projects/{project}/
+    │
+    └── lfp_aggregates/
+        ├── lf_compressed_all.h5              default level    (ε=150, α=28)  ~23 GB
+        └── lf_compressed_aggressive_all.h5   aggressive level (ε=450, α=96)  ~12 GB
+
+Each archive is a single multi-recording HDF5 file with one top-level group per
+insertion (``pid``), produced by ``lfpack.merge_h5``. The "aggressive" level trades
+fidelity for size; use "default" unless disk/bandwidth is the binding constraint.
+
+Downloading
+-----------
+
+.. code-block:: python
+
+    from pathlib import Path
+    from one.api import ONE
+    import ephysatlas.data
+
+    one = ONE(base_url='https://alyx.internationalbrainlab.org')
+    local_path = Path('/datadisk/ephys-atlas')
+    project = 'ibl_neuropixel_brainwide_01'
+
+    # default level (~23 GB)
+    ephysatlas.data.download_lfp_features(local_path, project=project, one=one)
+
+    # aggressive level (~12 GB)
+    ephysatlas.data.download_lfp_features(
+        local_path, project=project, one=one, level='aggressive'
+    )
+
+Loading
+-------
+
+.. code-block:: python
+
+    from pathlib import Path
+    import ephysatlas.data
+
+    local_path = Path('/datadisk/ephys-atlas')
+    project = 'ibl_neuropixel_brainwide_01'
+    pid = '00a824c0-e060-495f-9ebc-79c82fef4c67'
+
+    sr = ephysatlas.data.read_lfp_features(local_path / project, pid)
+    traces = sr[0:2500, :]          # (2500, nc) float32, volts
+    sr.nc, sr.fs                    # channel count, sample rate (Hz)
+
+``read_lfp_features`` returns an ``lfpack.LFPackReader``, a drop-in replacement for
+``spikeglx.Reader`` — chunks are decompressed on demand. Pass ``bin_channels=`` to
+sum adjacent channels on read, or ``scale=`` to open a coarser pyramidal level.
+
+See also
+--------
+
+* :doc:`s3-architecture` — complete S3 folder layout
+* :doc:`load-cells-features` — spike-triggered LFP (per-cell, not full recording)

--- a/docs/source/how-to/s3-architecture.rst
+++ b/docs/source/how-to/s3-architecture.rst
@@ -30,18 +30,21 @@ Folder Layout
     │   ├── model.ubj
     │   └── meta.yaml
     │
-    └── projects/{project}/                      ← per-project cluster aggregates
+    └── projects/{project}/                      ← per-project cluster/LFP aggregates
         ├── df_probe_details.pqt                 one row per probe insertion
-        └── cells_aggregates/
-            ├── clusters.table.pqt               all clusters (n_clusters × ~59)
-            ├── clusters_good.table.pqt          QC-passing clusters (n_good × ~61)
-            ├── clusters.acgs_log.npy            log-binned ACGs, normalised  (n_clusters × 128) float16
-            ├── acgs_log.times.npy               ACG bin centres in seconds   (128,) float64
-            ├── clusters.waveforms_peak.npy      peak-channel waveform        (n_clusters × 128) float16
-            ├── clusters_good.stpc.npy           spike-triggered population coupling  (n_good × 1000) float16
-            ├── clusters_good.stlfp.npy          spike-triggered LFP                  (n_good × 250)  float16
-            ├── waveforms.voltage.npy            neighbourhood traces (~8 GB)         (n_traces × 128) float16
-            └── waveforms.table.pqt              pid/cluster_id/abs_channel index     (n_traces × 3)
+        ├── cells_aggregates/
+        │   ├── clusters.table.pqt               all clusters (n_clusters × ~59)
+        │   ├── clusters_good.table.pqt          QC-passing clusters (n_good × ~61)
+        │   ├── clusters.acgs_log.npy            log-binned ACGs, normalised  (n_clusters × 128) float16
+        │   ├── acgs_log.times.npy               ACG bin centres in seconds   (128,) float64
+        │   ├── clusters.waveforms_peak.npy      peak-channel waveform        (n_clusters × 128) float16
+        │   ├── clusters_good.stpc.npy           spike-triggered population coupling  (n_good × 1000) float16
+        │   ├── clusters_good.stlfp.npy          spike-triggered LFP                  (n_good × 250)  float16
+        │   ├── waveforms.voltage.npy            neighbourhood traces (~8 GB)         (n_traces × 128) float16
+        │   └── waveforms.table.pqt              pid/cluster_id/abs_channel index     (n_traces × 3)
+        └── lfp_aggregates/                      ← merged LFP archives, one group per pid (lfpack)
+            ├── lf_compressed_all.h5             default level    (ε=150, α=28)  ~23 GB
+            └── lf_compressed_aggressive_all.h5  aggressive level (ε=450, α=96)  ~12 GB
 
 Versioning
 ----------
@@ -85,9 +88,12 @@ Download Functions
      - ``projects/{project}/cells_aggregates/``
    * - :func:`ephysatlas.data.download_project_data`
      - probe details + cell aggregates (convenience wrapper)
+   * - :func:`ephysatlas.data.download_lfp_features`
+     - ``projects/{project}/lfp_aggregates/``
 
 See also
 --------
 
 * :doc:`load-channel-features` — load channel-level features
 * :doc:`load-cells-features` — load cells features (stPC, stLFP)
+* :doc:`load-lfp-features` — load full-recording compressed LFP (lfpack)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dynamic = ["version"]
 dependencies = [
     "ibllib>=3.3.1",          # brainbox, ibllib.pipes, ONE-api (one.api/one.remote.aws), iblutil
     "ibl-neuropixel>=1.11.0", # ibldsp, neuropixel, spikeglx
+    "lfpack>=0.2.0",          # data.py read_lfp_features() lazy import (LFPackReader)
     "iblatlas",               # iblatlas.atlas/regions/genomics
     "xgboost>=3.0.1",         # regionclassifier (top-level import)
     "specparam==2.0.0rc3",    # features.lf() lazy import

--- a/src/ephysatlas/data.py
+++ b/src/ephysatlas/data.py
@@ -36,6 +36,11 @@ _WAVEFORMS_FILES = [
     "waveforms.voltage.npy",
     "waveforms.table.pqt",
 ]
+# Merged multi-recording LFP archives in lfp_aggregates/, keyed by compression level.
+_LFP_AGGREGATES_FILES = {
+    "default": "lf_compressed_all.h5",  # epsilon=150, alpha=28, ~23 GB
+    "aggressive": "lf_compressed_aggressive_all.h5",  # epsilon=450, alpha=96, ~12 GB
+}
 
 
 def get_waveforms_coordinates(
@@ -690,6 +695,94 @@ def read_cells_features(path_project):
         result["waveforms"] = np.load(path / "waveforms.voltage.npy", mmap_mode="r")
         result["df_waveforms"] = pd.read_parquet(path / "waveforms.table.pqt")
     return result
+
+
+def download_lfp_features(
+    local_path,
+    project="ibl_neuropixel_brainwide_01",
+    one=None,
+    overwrite=False,
+    level="default",
+):
+    """Download the merged LFP-compressed HDF5 archive from AWS S3.
+
+    The archive is a single multi-recording HDF5 file (produced by ``lfpack.merge_h5``)
+    containing one top-level group per insertion (pid). Use :func:`read_lfp_features`
+    to open a reader for a specific pid.
+
+    Parameters
+    ----------
+    local_path : Path
+        Local root; file is placed under ``local_path/project/lfp_aggregates/``.
+    project : str, optional
+        Project name. Defaults to "ibl_neuropixel_brainwide_01".
+    one : one.api.ONE, optional
+        ONE client instance for AWS authentication.
+    overwrite : bool, optional
+        Force re-download if the file already exists locally. Defaults to False.
+    level : {"default", "aggressive"}, optional
+        Compression level to download. "default" (epsilon=150, alpha=28, ~23 GB) is
+        higher fidelity; "aggressive" (epsilon=450, alpha=96, ~12 GB) trades fidelity
+        for size. Defaults to "default".
+
+    Returns
+    -------
+    Path
+        Local path to the downloaded HDF5 file.
+    """
+    assert level in _LFP_AGGREGATES_FILES, (
+        f"level must be one of {list(_LFP_AGGREGATES_FILES)}, got {level!r}"
+    )
+    s3, bucket_name, local_project_path = _project_s3(local_path, project, one)
+    dest = local_project_path.joinpath("lfp_aggregates")
+    dest.mkdir(parents=True, exist_ok=True)
+    fname = _LFP_AGGREGATES_FILES[level]
+    local_file = dest.joinpath(fname)
+    aws.s3_download_file(
+        f"aggregates/atlas/projects/{project}/lfp_aggregates/{fname}",
+        local_file,
+        s3=s3,
+        bucket_name=bucket_name,
+        overwrite=overwrite,
+    )
+    return local_file
+
+
+def read_lfp_features(path_project, pid, level="default", scale=0, bin_channels=1):
+    """Open a decompressed LFP reader for one insertion from the merged HDF5 archive.
+
+    Parameters
+    ----------
+    path_project : Path
+        Path to the project folder (parent of ``lfp_aggregates/``).
+    pid : str
+        Insertion ID; matches the top-level recording key in the merged HDF5 file.
+    level : {"default", "aggressive"}, optional
+        Compression level to read, matching the file downloaded by
+        :func:`download_lfp_features`. Defaults to "default".
+    scale : int, optional
+        Pyramidal resolution level to open, 0 = base full LFP rate. Defaults to 0.
+    bin_channels : int, optional
+        Number of adjacent channels to sum together on every read. Defaults to 1
+        (no binning).
+
+    Returns
+    -------
+    lfpack.LFPackReader
+        Drop-in ``spikeglx.Reader``-like object; chunks are decompressed on demand.
+        ``sr[0:2500, :]`` returns an ``(n_samples, n_channels)`` float32 array in volts.
+    """
+    import lfpack
+
+    assert level in _LFP_AGGREGATES_FILES, (
+        f"level must be one of {list(_LFP_AGGREGATES_FILES)}, got {level!r}"
+    )
+    h5_file = Path(path_project).joinpath(
+        "lfp_aggregates", _LFP_AGGREGATES_FILES[level]
+    )
+    return lfpack.LFPackReader(
+        h5_file, recording=pid, scale=scale, bin_channels=bin_channels
+    )
 
 
 def compute_depth_dataframe(df_raw_features, df_clusters, df_channels):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -240,3 +240,24 @@ class TestProjectDataIO(unittest.TestCase):
             large_files=False,
         )
         self.assertEqual(result, self.tmp / "dl" / self.project)
+
+    def test_download_lfp_features(self):
+        mock_one = MagicMock()
+        mock_one.alyx = MagicMock()
+        with patch("ephysatlas.data.aws") as mock_aws:
+            mock_aws.get_s3_from_alyx.return_value = (MagicMock(), "test-bucket")
+            ephysatlas.data.download_lfp_features(
+                self.tmp / "dl", project=self.project, one=mock_one
+            )
+        s3_key = mock_aws.s3_download_file.call_args[0][0]
+        self.assertEqual(
+            s3_key,
+            f"aggregates/atlas/projects/{self.project}/lfp_aggregates/lf_compressed_all.h5",
+        )
+
+    def test_read_lfp_features(self):
+        with patch("lfpack.LFPackReader") as mock_reader_cls:
+            ephysatlas.data.read_lfp_features(self.project_path, "pid123")
+        args, kwargs = mock_reader_cls.call_args
+        self.assertTrue(str(args[0]).endswith("lf_compressed_all.h5"))
+        self.assertEqual(kwargs["recording"], "pid123")


### PR DESCRIPTION
## Summary
- `download_lfp_features()` / `read_lfp_features()` in `ephysatlas.data` download and open the merged, full-recording LFP HDF5 archives produced by `lfpack`, stored under `aggregates/atlas/projects/{project}/lfp_aggregates/` on S3 (uploaded for `ibl_neuropixel_brainwide_01`).
- `read_lfp_features` returns an `lfpack.LFPackReader`, a drop-in `spikeglx.Reader`-like object, opened for a given pid from the multi-recording archive.
- Adds `lfpack` as a dependency.
- Adds a how-to doc page and updates the S3 architecture reference.

## Test plan
- [x] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/`
- [x] `uv run pytest` (excluding `test_region_classifier.py`, which segfaults on `main` too — pre-existing/environmental, unrelated to this change)
- [x] Manually verified `read_lfp_features` against the real uploaded archive (correct shape/dtype for a real pid)