### PR TITLE
Add 3D ACG compute + opt-in S3 loader support

### DIFF
--- a/docs/source/how-to/load-cells-features.rst
+++ b/docs/source/how-to/load-cells-features.rst
@@ -22,6 +22,8 @@ S3 Layout
         ├── clusters.waveforms_peak.npy           peak-channel waveform per cell                (n_cells × 128) float16
         ├── clusters_good.stpc.npy                spike-triggered population coupling           (n_good × 1000)    float16
         ├── clusters_good.stlfp.npy               spike-triggered LFP                           (n_good × 250)     float16
+        ├── clusters.acgs_3d.npy                  firing-rate-decile x log-time-lag 3D ACG (~3.5 GB) (n_cells × 10 × 201) float16
+        ├── acgs_3d.times.npy                     3D ACG log-time bin centres, ms                (201,) float64
         ├── waveforms.voltage.npy                 all neighbourhood traces (~8 GB)              (n_traces × 128)   float16
         └── waveforms.table.pqt                   pid / cluster_id / abs_channel index          (n_traces × 3)
 
@@ -29,6 +31,9 @@ S3 Layout
 long-lag asymptote converges to the firing rate in sp/s.
 Arrays indexed by cell are row-aligned with ``clusters.table.pqt``.
 Arrays indexed by good cell are row-aligned with ``clusters_good.table.pqt``.
+``clusters.acgs_3d.npy`` is also row-aligned with ``clusters.table.pqt`` (all cells,
+not just good units); see :func:`ephysatlas.cells.compute_3d_acgs` for how it is
+computed and recomputed on a new dataset.
 
 Downloading
 -----------
@@ -49,6 +54,9 @@ Downloading
     # include waveforms.voltage.npy + waveforms.table.pqt (~8 GB extra)
     ephysatlas.data.download_project_data(local_path, project=project, one=one, large_files=True)
 
+    # include clusters.acgs_3d.npy + acgs_3d.times.npy (~3.5 GB extra)
+    ephysatlas.data.download_project_data(local_path, project=project, one=one, acg3d=True)
+
 To download only one of the two parts:
 
 .. code-block:: python
@@ -57,6 +65,8 @@ To download only one of the two parts:
     ephysatlas.data.download_cells_features(local_path, project=project, one=one)
     # with neighbourhood waveforms:
     ephysatlas.data.download_cells_features(local_path, project=project, one=one, large_files=True)
+    # with 3D ACGs:
+    ephysatlas.data.download_cells_features(local_path, project=project, one=one, acg3d=True)
 
 Loading
 -------
@@ -80,6 +90,11 @@ Loading
     # present only when downloaded with large_files=True:
     waveforms            = r.get('waveforms')         # (n_traces × 128)   float16 memmap — ~8 GB
     df_waveforms         = r.get('df_waveforms')      # (n_traces × 3) — pid/cluster_id/abs_channel index
+    # present only when downloaded with acg3d=True:
+    acgs_3d              = r.get('acgs_3d')           # (n_cells × 10 × 201) float16 memmap — ~3.5 GB
+                                                        # firing-rate-decile x log-time-lag 3D ACG;
+                                                        # see ephysatlas.cells.compute_3d_acgs to recompute
+    acgs_3d_times         = r.get('acgs_3d_times')     # (201,) log-time bin centres, ms
 
 Joining with probe metadata
 ---------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ full = [
     "dartsort @ git+https://github.com/cwindolf/dartsort@iblsorter",
     "dredge @ git+https://github.com/evarol/dredge@v0.2.2",
     "spikeinterface>=0.101.2",
+    "npyx",                   # cells.compute_3d_acgs() lazy import; caps scikit-learn <1.6,
+                               # overridden workspace-wide (see root pyproject.toml [tool.uv])
     "hdbscan>=0.8.40",
     "h5py==3.15.1", #Some dartsort error arises in the unit tests, if I don't fix this.
     "linear-operator>=0.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,6 @@ full = [
     "dartsort @ git+https://github.com/cwindolf/dartsort@iblsorter",
     "dredge @ git+https://github.com/evarol/dredge@v0.2.2",
     "spikeinterface>=0.101.2",
-    "npyx",                   # cells.compute_3d_acgs() lazy import; caps scikit-learn <1.6,
-                               # overridden workspace-wide (see root pyproject.toml [tool.uv])
     "hdbscan>=0.8.40",
     "h5py==3.15.1", #Some dartsort error arises in the unit tests, if I don't fix this.
     "linear-operator>=0.6",

--- a/src/ephysatlas/cells.py
+++ b/src/ephysatlas/cells.py
@@ -465,3 +465,81 @@ def compute_log_acg(
         [_single_acg(spike_times[spike_clusters == cid]) for cid in cluster_ids]
     )
     return acg_log, t_log
+
+
+# ── 3D ACG (firing-rate decile x log-time-lag) ───────────────────────────────
+# Matches Han Yu's NEMO/ICLR pipeline (SteinmetzLab/slidingRefractory's sibling
+# compute_3dACG_IBL.py): linear ACG at cbin=1 ms / cwin=2000 ms via
+# spikeinterface (same algorithm as npyx.c4.fast_acg3d), then log-time resampled
+# via npyx.corr.convert_acg_log with its own defaults -> (n_clusters, 10, 201).
+# Recompute on a new dataset with these same constants to reproduce the released
+# format exactly.
+ACG3D_WINDOW_MS = 2000.0
+ACG3D_BIN_MS = 1.0
+ACG3D_NUM_FIRING_RATE_QUANTILES = 10
+ACG3D_SMOOTHING_MS = 250.0
+ACG3D_N_LOG_BINS = 100  # -> 2 * 100 + 1 = 201 bins after mirroring
+ACG3D_START_LOG_MS = 0.8
+ACG3D_SMOOTH_SD = 1
+
+
+def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
+    """
+    Firing-rate-decile x log-time-lag 3D autocorrelogram, one per cluster.
+
+    Computes the linear-time 3D ACG (spikeinterface's ``compute_acgs_3d``, the
+    same algorithm as ``npyx.c4.fast_acg3d``), then resamples each cluster onto
+    Han Yu's NEMO/ICLR log-time axis via ``npyx.corr.convert_acg_log`` (the real
+    function, not a port, for exact numerical fidelity: interpolation, gaussian
+    smoothing, and mirroring). Uses this module's ``ACG3D_*`` constants; call
+    with unmodified constants to reproduce a reference dataset exactly.
+
+    Requires the optional ``npyx`` and ``spikeinterface`` dependencies
+    (``pip install ibleatools[full]``); imported lazily here so the rest of
+    this module stays usable without them.
+
+    Parameters
+    ----------
+    spike_times : numpy.ndarray
+        Spike times for the whole recording, in seconds.
+    spike_clusters : numpy.ndarray
+        Cluster id of each spike, same length as `spike_times`.
+    cluster_ids : numpy.ndarray
+        Clusters to compute the ACG for; defines the output row order.
+    fs : float
+        Sampling frequency of `spike_times`, in Hz.
+
+    Returns
+    -------
+    acgs_3d : numpy.ndarray
+        (len(cluster_ids), ACG3D_NUM_FIRING_RATE_QUANTILES, 201) float32 array.
+    t_log : numpy.ndarray
+        (201,) log-time bin centres, in ms (negative, zero, then positive lags).
+    """
+    from spikeinterface.core import NumpySorting
+    from spikeinterface.postprocessing import compute_acgs_3d
+    from npyx.corr import convert_acg_log
+
+    sorting = NumpySorting.from_samples_and_labels(
+        samples_list=np.round(spike_times * fs).astype(np.int64),
+        labels_list=spike_clusters,
+        sampling_frequency=fs,
+        unit_ids=cluster_ids,
+    )
+    acgs_3d_lin, _, _ = compute_acgs_3d(
+        sorting,
+        window_ms=ACG3D_WINDOW_MS,
+        bin_ms=ACG3D_BIN_MS,
+        num_firing_rate_quantiles=ACG3D_NUM_FIRING_RATE_QUANTILES,
+        smoothing_factor=ACG3D_SMOOTHING_MS,
+        n_jobs=1,
+    )
+    n_bins = 2 * ACG3D_N_LOG_BINS + 1
+    acgs_3d = np.empty((acgs_3d_lin.shape[0], ACG3D_NUM_FIRING_RATE_QUANTILES, n_bins), dtype=np.float32)
+    t_log = None
+    for i, acg_lin in enumerate(acgs_3d_lin):
+        acgs_3d[i], t_log = convert_acg_log(
+            acg_lin, cbin=ACG3D_BIN_MS, cwin=ACG3D_WINDOW_MS, n_log_bins=ACG3D_N_LOG_BINS,
+            start_log_ms=ACG3D_START_LOG_MS, smooth_sd=ACG3D_SMOOTH_SD,
+        )
+    return acgs_3d, t_log

--- a/src/ephysatlas/cells.py
+++ b/src/ephysatlas/cells.py
@@ -535,10 +535,16 @@ def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
         n_jobs=1,
     )
     n_bins = 2 * ACG3D_N_LOG_BINS + 1
-    acgs_3d = np.empty((acgs_3d_lin.shape[0], ACG3D_NUM_FIRING_RATE_QUANTILES, n_bins), dtype=np.float32)
+    acgs_3d = np.empty(
+        (acgs_3d_lin.shape[0], ACG3D_NUM_FIRING_RATE_QUANTILES, n_bins),
+        dtype=np.float32,
+    )
     t_log = None
     for i, acg_lin in enumerate(acgs_3d_lin):
         acgs_3d[i], t_log = convert_acg_log(
-            acg_lin, cbin=ACG3D_BIN_MS, cwin=ACG3D_WINDOW_MS, n_log_bins=ACG3D_N_LOG_BINS,
+            acg_lin,
+            cbin=ACG3D_BIN_MS,
+            cwin=ACG3D_WINDOW_MS,
+            n_log_bins=ACG3D_N_LOG_BINS,
         )
     return acgs_3d, t_log

--- a/src/ephysatlas/cells.py
+++ b/src/ephysatlas/cells.py
@@ -28,6 +28,54 @@ import iblatlas.regions
 BINSIZE = 0.001
 LAG = 0.5
 
+# Standard bitwise_fail threshold for the sliding-RP bit (brainbox.metrics.single_units
+# .compute_labels, METRICS_PARAMS['RPmax_confidence']), percent (0-100) scale.
+BITWISE_FAIL_RP_CONFIDENCE_THRESHOLD = 90.0
+# bitwise_fail bit layout (brainbox.metrics.single_units.compute_labels): bit 0 (value 1)
+# = sliding-RP confidence, bit 1 (value 2) = noise_cutoff, bit 2 (value 4) = amp_median.
+_BITWISE_FAIL_NOISE_AMP_MASK = 0b110
+
+
+def select_good_units_relaxed_rp(df_clusters, rp_confidence_threshold=70.0):
+    """Good-unit mask with a relaxed sliding-refractory-period inclusion criterion.
+
+    The standard good-unit definition (``bitwise_fail == 0``, computed upstream by
+    ``brainbox.metrics.single_units.compute_labels``) requires the legacy sliding-RP
+    metric to reach :data:`BITWISE_FAIL_RP_CONFIDENCE_THRESHOLD` (90%) confidence
+    (bit 0 of ``bitwise_fail``). This keeps the noise-cutoff and amplitude vetoes
+    (bits 1-2) unchanged, but swaps that RP bit for a relaxed threshold on the v2
+    sliding-RP metric (``slidingRP2_max_confidence``, computed by
+    ``compute_sliding_rp_v2`` in the SDSC cells pipeline), letting through units
+    whose refractory-period confidence is lower than 90% but still above
+    `rp_confidence_threshold`.
+
+    Parameters
+    ----------
+    df_clusters : pandas.DataFrame
+        Cluster-level metadata; must include ``bitwise_fail`` and
+        ``slidingRP2_max_confidence`` columns.
+    rp_confidence_threshold : float, optional
+        Minimum ``slidingRP2_max_confidence`` (0-100 scale) to pass. Defaults to 70.0,
+        vs the standard 90.0 baked into ``bitwise_fail``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean mask, one entry per row of `df_clusters`. Clusters with a NaN
+        `slidingRP2_max_confidence` (too few spikes to compute) are treated as fail.
+    """
+    required_columns = {"bitwise_fail", "slidingRP2_max_confidence"}
+    missing_columns = required_columns - set(df_clusters.columns)
+    assert not missing_columns, f"df_clusters is missing columns: {missing_columns}"
+
+    noise_amp_pass = (
+        df_clusters["bitwise_fail"].to_numpy() & _BITWISE_FAIL_NOISE_AMP_MASK
+    ) == 0
+    rp_pass = (
+        df_clusters["slidingRP2_max_confidence"].to_numpy() >= rp_confidence_threshold
+    )
+    return noise_amp_pass & rp_pass
+
 
 def get_neighbours_members(df_clusters, radius_um):
     """

--- a/src/ephysatlas/cells.py
+++ b/src/ephysatlas/cells.py
@@ -468,19 +468,18 @@ def compute_log_acg(
 
 
 # ── 3D ACG (firing-rate decile x log-time-lag) ───────────────────────────────
-# Matches Han Yu's NEMO/ICLR pipeline (SteinmetzLab/slidingRefractory's sibling
-# compute_3dACG_IBL.py): linear ACG at cbin=1 ms / cwin=2000 ms via
-# spikeinterface (same algorithm as npyx.c4.fast_acg3d), then log-time resampled
-# via npyx.corr.convert_acg_log with its own defaults -> (n_clusters, 10, 201).
-# Recompute on a new dataset with these same constants to reproduce the released
-# format exactly.
+# Matches Han Yu's NEMO/ICLR pipeline (compute_3dACG_IBL.py): linear ACG at
+# cbin=1 ms / cwin=2000 ms via spikeinterface (same algorithm as
+# npyx.c4.fast_acg3d), then log-time resampled -> (n_clusters, 10, 201). The
+# log-resampling step is vendored in ephysatlas.iblnpyx (see that module's
+# docstring for why) rather than depended on directly; expect to swap it back
+# to a plain npyx dependency once that's resolved upstream. Recompute on a new
+# dataset with these same constants to reproduce the released format exactly.
 ACG3D_WINDOW_MS = 2000.0
 ACG3D_BIN_MS = 1.0
 ACG3D_NUM_FIRING_RATE_QUANTILES = 10
 ACG3D_SMOOTHING_MS = 250.0
 ACG3D_N_LOG_BINS = 100  # -> 2 * 100 + 1 = 201 bins after mirroring
-ACG3D_START_LOG_MS = 0.8
-ACG3D_SMOOTH_SD = 1
 
 
 def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
@@ -489,14 +488,14 @@ def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
 
     Computes the linear-time 3D ACG (spikeinterface's ``compute_acgs_3d``, the
     same algorithm as ``npyx.c4.fast_acg3d``), then resamples each cluster onto
-    Han Yu's NEMO/ICLR log-time axis via ``npyx.corr.convert_acg_log`` (the real
-    function, not a port, for exact numerical fidelity: interpolation, gaussian
-    smoothing, and mirroring). Uses this module's ``ACG3D_*`` constants; call
-    with unmodified constants to reproduce a reference dataset exactly.
+    Han Yu's NEMO/ICLR log-time axis via
+    :func:`ephysatlas.iblnpyx.convert_acg_log`. Uses this module's ``ACG3D_*``
+    constants; call with unmodified constants to reproduce a reference dataset
+    exactly.
 
-    Requires the optional ``npyx`` and ``spikeinterface`` dependencies
-    (``pip install ibleatools[full]``); imported lazily here so the rest of
-    this module stays usable without them.
+    Requires the optional ``spikeinterface`` dependency (``pip install
+    ibleatools[full]``); imported lazily here so the rest of this module stays
+    usable without it.
 
     Parameters
     ----------
@@ -518,7 +517,8 @@ def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
     """
     from spikeinterface.core import NumpySorting
     from spikeinterface.postprocessing import compute_acgs_3d
-    from npyx.corr import convert_acg_log
+
+    from ephysatlas.iblnpyx import convert_acg_log
 
     sorting = NumpySorting.from_samples_and_labels(
         samples_list=np.round(spike_times * fs).astype(np.int64),
@@ -540,6 +540,5 @@ def compute_3d_acgs(spike_times, spike_clusters, cluster_ids, fs):
     for i, acg_lin in enumerate(acgs_3d_lin):
         acgs_3d[i], t_log = convert_acg_log(
             acg_lin, cbin=ACG3D_BIN_MS, cwin=ACG3D_WINDOW_MS, n_log_bins=ACG3D_N_LOG_BINS,
-            start_log_ms=ACG3D_START_LOG_MS, smooth_sd=ACG3D_SMOOTH_SD,
         )
     return acgs_3d, t_log

--- a/src/ephysatlas/cells.py
+++ b/src/ephysatlas/cells.py
@@ -40,40 +40,36 @@ def select_good_units_relaxed_rp(df_clusters, rp_confidence_threshold=70.0):
     """Good-unit mask with a relaxed sliding-refractory-period inclusion criterion.
 
     The standard good-unit definition (``bitwise_fail == 0``, computed upstream by
-    ``brainbox.metrics.single_units.compute_labels``) requires the legacy sliding-RP
-    metric to reach :data:`BITWISE_FAIL_RP_CONFIDENCE_THRESHOLD` (90%) confidence
-    (bit 0 of ``bitwise_fail``). This keeps the noise-cutoff and amplitude vetoes
-    (bits 1-2) unchanged, but swaps that RP bit for a relaxed threshold on the v2
-    sliding-RP metric (``slidingRP2_max_confidence``, computed by
-    ``compute_sliding_rp_v2`` in the SDSC cells pipeline), letting through units
-    whose refractory-period confidence is lower than 90% but still above
-    `rp_confidence_threshold`.
+    ``brainbox.metrics.single_units.compute_labels``) requires the sliding-RP metric
+    (``max_confidence``) to reach :data:`BITWISE_FAIL_RP_CONFIDENCE_THRESHOLD` (90%)
+    confidence (bit 0 of ``bitwise_fail``). This keeps the noise-cutoff and amplitude
+    vetoes (bits 1-2) unchanged, but relaxes that RP bit to `rp_confidence_threshold`
+    applied directly to ``max_confidence``, letting through units whose
+    refractory-period confidence is lower than 90% but still above the threshold.
 
     Parameters
     ----------
     df_clusters : pandas.DataFrame
-        Cluster-level metadata; must include ``bitwise_fail`` and
-        ``slidingRP2_max_confidence`` columns.
+        Cluster-level metadata; must include ``bitwise_fail`` and ``max_confidence``
+        columns.
     rp_confidence_threshold : float, optional
-        Minimum ``slidingRP2_max_confidence`` (0-100 scale) to pass. Defaults to 70.0,
-        vs the standard 90.0 baked into ``bitwise_fail``.
+        Minimum ``max_confidence`` (0-100 scale) to pass. Defaults to 70.0, vs the
+        standard 90.0 baked into ``bitwise_fail``.
 
     Returns
     -------
     numpy.ndarray
         Boolean mask, one entry per row of `df_clusters`. Clusters with a NaN
-        `slidingRP2_max_confidence` (too few spikes to compute) are treated as fail.
+        `max_confidence` (too few spikes to compute) are treated as fail.
     """
-    required_columns = {"bitwise_fail", "slidingRP2_max_confidence"}
+    required_columns = {"bitwise_fail", "max_confidence"}
     missing_columns = required_columns - set(df_clusters.columns)
     assert not missing_columns, f"df_clusters is missing columns: {missing_columns}"
 
     noise_amp_pass = (
         df_clusters["bitwise_fail"].to_numpy() & _BITWISE_FAIL_NOISE_AMP_MASK
     ) == 0
-    rp_pass = (
-        df_clusters["slidingRP2_max_confidence"].to_numpy() >= rp_confidence_threshold
-    )
+    rp_pass = df_clusters["max_confidence"].to_numpy() >= rp_confidence_threshold
     return noise_amp_pass & rp_pass
 
 

--- a/src/ephysatlas/data.py
+++ b/src/ephysatlas/data.py
@@ -36,6 +36,12 @@ _WAVEFORMS_FILES = [
     "waveforms.voltage.npy",
     "waveforms.table.pqt",
 ]
+# 3D (firing-rate-decile x log-time-lag) ACGs (~3.5 GB) — opt-in, not every
+# historical dataset has these (see ephysatlas.cells.compute_3d_acgs)
+_ACG3D_FILES = [
+    "clusters.acgs_3d.npy",
+    "acgs_3d.times.npy",
+]
 # Merged multi-recording LFP archives in lfp_aggregates/, keyed by compression level.
 _LFP_AGGREGATES_FILES = {
     "default": "lf_compressed_all.h5",  # epsilon=150, alpha=28, ~23 GB
@@ -569,12 +575,14 @@ def download_cells_features(
     one=None,
     overwrite=False,
     large_files=False,
+    acg3d=False,
 ):
     """Download cluster-level aggregates from S3 (``cells_aggregates/`` subfolder, ~1 GB).
 
     Downloads the standard cluster files. The large waveform files
     (``waveforms.voltage.npy`` and ``waveforms.table.pqt``, ~8 GB combined) are only
-    downloaded when ``large_files=True``.
+    downloaded when ``large_files=True``. The 3D ACG files (``clusters.acgs_3d.npy``
+    and ``acgs_3d.times.npy``, ~3.5 GB) are only downloaded when ``acg3d=True``.
 
     Use :func:`download_probe_details` if you only need probe metadata, or
     :func:`download_project_data` to get both in one call.
@@ -586,6 +594,8 @@ def download_cells_features(
         overwrite (bool): Re-download files that already exist locally.
         large_files (bool): If True, also download waveforms.voltage.npy and waveforms.table.pqt
             (~8 GB). Defaults to False.
+        acg3d (bool): If True, also download clusters.acgs_3d.npy and acgs_3d.times.npy
+            (~3.5 GB). Not every historical dataset has these. Defaults to False.
 
     Returns:
         Path: local_path/project/cells_aggregates/ directory.
@@ -594,8 +604,10 @@ def download_cells_features(
     dest = local_project_path / "cells_aggregates"
     dest.mkdir(parents=True, exist_ok=True)
     s3_prefix = f"aggregates/atlas/projects/{project}/cells_aggregates"
-    files_to_download = _CELLS_AGGREGATES_FILES + (
-        _WAVEFORMS_FILES if large_files else []
+    files_to_download = (
+        _CELLS_AGGREGATES_FILES
+        + (_WAVEFORMS_FILES if large_files else [])
+        + (_ACG3D_FILES if acg3d else [])
     )
     for fname in files_to_download:
         aws.s3_download_file(
@@ -614,6 +626,7 @@ def download_project_data(
     one=None,
     overwrite=False,
     large_files=False,
+    acg3d=False,
 ):
     """Download all project data (probe details + cell aggregates) from S3.
 
@@ -625,6 +638,7 @@ def download_project_data(
         one (one.api.ONE, optional): ONE instance for AWS credentials.
         overwrite (bool): Re-download files that already exist locally.
         large_files (bool): If True, also download the large waveform files (~8 GB). Defaults to False.
+        acg3d (bool): If True, also download the 3D ACG files (~3.5 GB). Defaults to False.
 
     Returns:
         Path: local_path/project directory.
@@ -636,6 +650,7 @@ def download_project_data(
         one=one,
         overwrite=overwrite,
         large_files=large_files,
+        acg3d=acg3d,
     )
     return Path(local_path) / project
 
@@ -672,6 +687,7 @@ def read_cells_features(path_project):
         Always present: df_clusters, df_clusters_good, acgs_log, acgs_log_times,
         waveforms_peak, stpc, stlfp.
         Present only if downloaded with ``large_files=True``: waveforms, df_waveforms.
+        Present only if downloaded with ``acg3d=True``: acgs_3d, acgs_3d_times.
 
     See Also
     --------
@@ -694,6 +710,11 @@ def read_cells_features(path_project):
     if (path / "waveforms.voltage.npy").exists():
         result["waveforms"] = np.load(path / "waveforms.voltage.npy", mmap_mode="r")
         result["df_waveforms"] = pd.read_parquet(path / "waveforms.table.pqt")
+    if (path / "clusters.acgs_3d.npy").exists():
+        # stays a float16 memmap rather than eager-cast to float32 (as acgs_log
+        # does): at (n_clusters, 10, 201) this array is ~3.5 GB even at float16.
+        result["acgs_3d"] = np.load(path / "clusters.acgs_3d.npy", mmap_mode="r")
+        result["acgs_3d_times"] = np.load(path / "acgs_3d.times.npy")
     return result
 
 

--- a/src/ephysatlas/iblnpyx.py
+++ b/src/ephysatlas/iblnpyx.py
@@ -69,8 +69,10 @@ def smooth_gaussian_axis0(arr, sd):
         kernel = np.append(kernel, np.zeros(mx - (len(kernel) - mx)))
     kernel = kernel / kernel.sum()
 
-    smoothed = np.apply_along_axis(lambda m: np.convolve(m, kernel, mode="same"), axis=0, arr=padded)
-    return smoothed[c + 1: smoothed.shape[0] - c + 1]
+    smoothed = np.apply_along_axis(
+        lambda m: np.convolve(m, kernel, mode="same"), axis=0, arr=padded
+    )
+    return smoothed[c + 1 : smoothed.shape[0] - c + 1]
 
 
 def convert_acg_log(lin_acg, cbin, cwin, n_log_bins=100, start_log_ms=0.8, smooth_sd=1):

--- a/src/ephysatlas/iblnpyx.py
+++ b/src/ephysatlas/iblnpyx.py
@@ -1,0 +1,135 @@
+"""
+Vendored numerics from npyx (SteinmetzLab/NeuroPyxels), used by
+``ephysatlas.cells.compute_3d_acgs`` to log-time-resample linear autocorrelograms
+into Han Yu's NEMO/ICLR 3D-ACG format.
+
+Why vendored instead of depended on
+------------------------------------
+``npyx`` pulls in a large, fragile dependency chain for the ~40 lines actually
+used here (``npyx.corr.convert_acg_log`` / ``npyx.utils.smooth``):
+
+- Its ``scikit-learn<1.6.0`` pin conflicts with ``ibleatools``'s own validated
+  ``scikit-learn`` range (1.6-1.8; see ``packages/ibleatools/pyproject.toml``).
+- Its unpinned ``ipython`` dependency resolved to IPython>=9, which removed the
+  ``IPython.core.display.display`` re-export that ``npyx.plot_utils`` imports
+  at module load time — breaking ``import npyx`` outright.
+- ``npyx/circuitProphyler.py`` (eagerly imported by ``npyx/__init__.py``, and
+  otherwise unrelated to anything used here) does ``import imp``, a stdlib
+  module removed in Python 3.12.
+
+This module is a short-term fix. The plan is to reach a consensus with the
+npyx maintainer (a lighter-weight ``npyx``-core package, or fixes to the above)
+and remove this file in favour of a normal dependency.
+
+License
+-------
+npyx is GPL-3.0-licensed (see https://github.com/m-beau/NeuroPyxels). The
+functions below are copied near-verbatim from ``npyx/corr.py`` and
+``npyx/utils.py``. Unlike the rest of ``ephysatlas`` (MIT), THIS FILE is
+therefore under the terms of the GPL-3.0 license.
+"""
+
+import numpy as np
+import scipy.stats
+
+
+def smooth_gaussian_axis0(arr, sd):
+    """
+    Symmetric gaussian smoothing along axis 0.
+
+    Axis/method-specialised port of ``npyx.utils.smooth(arr, method='gaussian',
+    sd=sd, axis=0)``. Kept numerically identical, including the kernel
+    zero-padding step below (a quirk of the original, general-purpose
+    implementation): npyx re-centres an even-length kernel by zero-padding one
+    side, based on the (for a symmetric gaussian, always slightly off-centre
+    for an odd-length ``arange``) argmax position.
+
+    Parameters
+    ----------
+    arr : numpy.ndarray
+        1-D or 2-D array to smooth along axis 0.
+    sd : int
+        Gaussian kernel standard deviation, in samples along axis 0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Smoothed array, same shape as `arr`.
+    """
+    c = arr.shape[0] // 2
+    pad_width = [(c, c)] + [(0, 0)] * (arr.ndim - 1)
+    padded = np.pad(arr, pad_width, "symmetric")
+
+    x = np.arange(-4 * sd, 4 * sd + 1)
+    kernel = scipy.stats.norm.pdf(x, 0, sd)
+    mx = np.argmax(kernel)
+    if mx < len(kernel) / 2:
+        kernel = np.append(np.zeros(len(kernel) - 2 * mx), kernel)
+    elif mx > len(kernel) / 2:
+        kernel = np.append(kernel, np.zeros(mx - (len(kernel) - mx)))
+    kernel = kernel / kernel.sum()
+
+    smoothed = np.apply_along_axis(lambda m: np.convolve(m, kernel, mode="same"), axis=0, arr=padded)
+    return smoothed[c + 1: smoothed.shape[0] - c + 1]
+
+
+def convert_acg_log(lin_acg, cbin, cwin, n_log_bins=100, start_log_ms=0.8, smooth_sd=1):
+    """
+    Resample a linear-time ACG onto a log-time axis.
+
+    Non-plotting port of ``npyx.corr.convert_acg_log``. Interpolates the linear
+    ACG's positive lags onto `n_log_bins` log-spaced points, smooths, then
+    mirrors to cover negative lags too.
+
+    Parameters
+    ----------
+    lin_acg : numpy.ndarray
+        (n_bins,) or (n_freqs, n_bins) linear-time ACG.
+    cbin, cwin : float
+        Linear bin size / full window used to compute `lin_acg`, in ms.
+    n_log_bins : int
+        Number of log-spaced bins per side (mirrored -> 2*n_log_bins+1 total).
+    start_log_ms : float or None
+        Discard log bins below this lag, in ms; None to keep all.
+    smooth_sd : int or None
+        Gaussian smoothing std, in log-bin samples; None to disable.
+
+    Returns
+    -------
+    log_acg : numpy.ndarray
+        (2*n_log_bins+1,) or (n_freqs, 2*n_log_bins+1) log-time ACG.
+    t_log : numpy.ndarray
+        (2*n_log_bins+1,) log-time bin centres, in ms (negative, zero, positive).
+    """
+    assert cbin <= cwin
+    assert n_log_bins > 1
+    if start_log_ms is not None:
+        assert start_log_ms > 0
+
+    original_bins = np.arange(-cwin // 2, cwin // 2 + cbin, cbin)
+    lin_acg = lin_acg.T  # (n_freqs, n_bins) -> (n_bins, n_freqs) if 2D
+    assert original_bins.shape[0] == lin_acg.shape[0]
+    half_i = len(original_bins) // 2 + 1
+    lin_bins = original_bins[half_i:]
+    log_bins = np.logspace(np.log10(lin_bins[0]), np.log10(lin_bins[-1]), n_log_bins)
+
+    if lin_acg.ndim == 2:
+        log_acg = np.zeros((len(log_bins), lin_acg.shape[1]))
+        for acg_i, lin_a in enumerate(lin_acg[half_i:, :].T):
+            log_acg[:, acg_i] = np.interp(log_bins, lin_bins, lin_a)
+    else:
+        log_acg = np.interp(log_bins, lin_bins, lin_acg[half_i:])
+
+    if start_log_ms is not None:
+        keep = log_bins >= start_log_ms
+        log_bins = log_bins[keep]
+        log_acg = log_acg[keep]
+
+    if smooth_sd is not None:
+        log_acg = smooth_gaussian_axis0(log_acg, smooth_sd)
+
+    t_log = np.concatenate((-log_bins[::-1], [0], log_bins))
+    zeros = [0] if lin_acg.ndim == 1 else np.zeros((1, log_acg.shape[1]))
+    log_acg = np.concatenate((log_acg[::-1], zeros, log_acg), axis=0)
+
+    return log_acg.T, t_log

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -10,6 +10,7 @@ try:
         ACG3D_NUM_FIRING_RATE_QUANTILES,
         compute_3d_acgs,
     )
+
     _HAS_ACG3D_DEPS = True
 except ImportError:
     _HAS_ACG3D_DEPS = False
@@ -137,8 +138,12 @@ class TestCompute3DAcgs(unittest.TestCase):
     def test_output_shape(self):
         spike_times = self._dummy_spike_train()
         spike_clusters = np.zeros(spike_times.size, dtype=int)
-        acgs_3d, t_log = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
-        self.assertEqual(acgs_3d.shape, (1, ACG3D_NUM_FIRING_RATE_QUANTILES, self.N_BINS))
+        acgs_3d, t_log = compute_3d_acgs(
+            spike_times, spike_clusters, np.array([0]), self.FS
+        )
+        self.assertEqual(
+            acgs_3d.shape, (1, ACG3D_NUM_FIRING_RATE_QUANTILES, self.N_BINS)
+        )
         self.assertEqual(t_log.shape, (self.N_BINS,))
 
     def test_t_log_symmetric_and_monotone(self):
@@ -148,12 +153,14 @@ class TestCompute3DAcgs(unittest.TestCase):
         self.assertTrue(np.all(np.diff(t_log) > 0), "t_log must be strictly increasing")
         mid = self.N_BINS // 2
         self.assertAlmostEqual(t_log[mid], 0.0)
-        np.testing.assert_allclose(t_log[:mid], -t_log[mid + 1:][::-1])
+        np.testing.assert_allclose(t_log[:mid], -t_log[mid + 1 :][::-1])
 
     def test_values_finite_and_nonnegative(self):
         spike_times = self._dummy_spike_train()
         spike_clusters = np.zeros(spike_times.size, dtype=int)
-        acgs_3d, _ = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
+        acgs_3d, _ = compute_3d_acgs(
+            spike_times, spike_clusters, np.array([0]), self.FS
+        )
         self.assertTrue(np.all(np.isfinite(acgs_3d)))
         self.assertTrue(np.all(acgs_3d >= 0))
 
@@ -167,17 +174,23 @@ class TestCompute3DAcgs(unittest.TestCase):
         )
         order = np.argsort(spike_times)
         spike_times, spike_clusters = spike_times[order], spike_clusters[order]
-        acgs_3d, _ = compute_3d_acgs(spike_times, spike_clusters, np.array([0, 1]), self.FS)
+        acgs_3d, _ = compute_3d_acgs(
+            spike_times, spike_clusters, np.array([0, 1]), self.FS
+        )
         self.assertEqual(acgs_3d.shape[0], 2)
         self.assertFalse(np.array_equal(acgs_3d[0], acgs_3d[1]))
 
     def test_refractory_period_visible_near_zero_lag(self):
         """A hard refractory period should show lower density near zero lag than far from it."""
-        spike_times = self._dummy_spike_train(duration=120.0, rate=30.0, refractory=0.01)
+        spike_times = self._dummy_spike_train(
+            duration=120.0, rate=30.0, refractory=0.01
+        )
         spike_clusters = np.zeros(spike_times.size, dtype=int)
-        acgs_3d, t_log = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
-        near_zero = np.abs(t_log) < 5    # ms
-        far = np.abs(t_log) > 200        # ms
+        acgs_3d, t_log = compute_3d_acgs(
+            spike_times, spike_clusters, np.array([0]), self.FS
+        )
+        near_zero = np.abs(t_log) < 5  # ms
+        far = np.abs(t_log) > 200  # ms
         self.assertLess(acgs_3d[0][:, near_zero].mean(), acgs_3d[0][:, far].mean())
 
 

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -4,6 +4,16 @@ import numpy as np
 
 from ephysatlas.cells import compute_burstiness_and_memory, compute_log_acg
 
+try:
+    from ephysatlas.cells import (
+        ACG3D_N_LOG_BINS,
+        ACG3D_NUM_FIRING_RATE_QUANTILES,
+        compute_3d_acgs,
+    )
+    _HAS_ACG3D_DEPS = True
+except ImportError:
+    _HAS_ACG3D_DEPS = False
+
 
 class TestComputeBurstinessAndMemory(unittest.TestCase):
     def test_too_few_spikes_returns_nan(self):
@@ -108,6 +118,67 @@ class TestComputeLogAcg(unittest.TestCase):
         for i, cid in enumerate([0, 1]):
             acg_single, _ = compute_log_acg(spike_times[spike_clusters == cid], self.FS)
             np.testing.assert_array_equal(acg_multi[i], acg_single)
+
+
+@unittest.skipUnless(_HAS_ACG3D_DEPS, "requires ibleatools[full] (spikeinterface)")
+class TestCompute3DAcgs(unittest.TestCase):
+    """Wiring smoke test: spikeinterface (linear ACG) -> npyx (log resampling)."""
+
+    FS = 30_000  # synthetic AP-band sampling rate, Hz
+    N_BINS = 2 * ACG3D_N_LOG_BINS + 1
+
+    def _dummy_spike_train(self, seed=0, duration=60.0, rate=20.0, refractory=0.003):
+        """Poisson-ish spike train (as cumulative ISIs) with an enforced refractory period."""
+        rng = np.random.default_rng(seed)
+        isis = rng.exponential(1 / rate, int(duration * rate * 2))
+        isis = isis[isis > refractory][: int(duration * rate)]
+        return np.cumsum(isis)
+
+    def test_output_shape(self):
+        spike_times = self._dummy_spike_train()
+        spike_clusters = np.zeros(spike_times.size, dtype=int)
+        acgs_3d, t_log = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
+        self.assertEqual(acgs_3d.shape, (1, ACG3D_NUM_FIRING_RATE_QUANTILES, self.N_BINS))
+        self.assertEqual(t_log.shape, (self.N_BINS,))
+
+    def test_t_log_symmetric_and_monotone(self):
+        spike_times = self._dummy_spike_train()
+        spike_clusters = np.zeros(spike_times.size, dtype=int)
+        _, t_log = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
+        self.assertTrue(np.all(np.diff(t_log) > 0), "t_log must be strictly increasing")
+        mid = self.N_BINS // 2
+        self.assertAlmostEqual(t_log[mid], 0.0)
+        np.testing.assert_allclose(t_log[:mid], -t_log[mid + 1:][::-1])
+
+    def test_values_finite_and_nonnegative(self):
+        spike_times = self._dummy_spike_train()
+        spike_clusters = np.zeros(spike_times.size, dtype=int)
+        acgs_3d, _ = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
+        self.assertTrue(np.all(np.isfinite(acgs_3d)))
+        self.assertTrue(np.all(acgs_3d >= 0))
+
+    def test_multi_cluster_row_order(self):
+        """Two clusters at different rates should produce two independent rows."""
+        st0 = self._dummy_spike_train(seed=1, rate=10.0)
+        st1 = self._dummy_spike_train(seed=2, rate=30.0)
+        spike_times = np.concatenate([st0, st1])
+        spike_clusters = np.concatenate(
+            [np.zeros(st0.size, dtype=int), np.ones(st1.size, dtype=int)]
+        )
+        order = np.argsort(spike_times)
+        spike_times, spike_clusters = spike_times[order], spike_clusters[order]
+        acgs_3d, _ = compute_3d_acgs(spike_times, spike_clusters, np.array([0, 1]), self.FS)
+        self.assertEqual(acgs_3d.shape[0], 2)
+        self.assertFalse(np.array_equal(acgs_3d[0], acgs_3d[1]))
+
+    def test_refractory_period_visible_near_zero_lag(self):
+        """A hard refractory period should show lower density near zero lag than far from it."""
+        spike_times = self._dummy_spike_train(duration=120.0, rate=30.0, refractory=0.01)
+        spike_clusters = np.zeros(spike_times.size, dtype=int)
+        acgs_3d, t_log = compute_3d_acgs(spike_times, spike_clusters, np.array([0]), self.FS)
+        near_zero = np.abs(t_log) < 5    # ms
+        far = np.abs(t_log) > 200        # ms
+        self.assertLess(acgs_3d[0][:, near_zero].mean(), acgs_3d[0][:, far].mean())
 
 
 if __name__ == "__main__":

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -1,8 +1,13 @@
 import unittest
 
 import numpy as np
+import pandas as pd
 
-from ephysatlas.cells import compute_burstiness_and_memory, compute_log_acg
+from ephysatlas.cells import (
+    compute_burstiness_and_memory,
+    compute_log_acg,
+    select_good_units_relaxed_rp,
+)
 
 try:
     from ephysatlas.cells import (
@@ -192,6 +197,53 @@ class TestCompute3DAcgs(unittest.TestCase):
         near_zero = np.abs(t_log) < 5  # ms
         far = np.abs(t_log) > 200  # ms
         self.assertLess(acgs_3d[0][:, near_zero].mean(), acgs_3d[0][:, far].mean())
+
+
+class TestSelectGoodUnitsRelaxedRp(unittest.TestCase):
+    def _df(self, bitwise_fail, slidingRP2_max_confidence):
+        return pd.DataFrame(
+            {
+                "bitwise_fail": bitwise_fail,
+                "slidingRP2_max_confidence": slidingRP2_max_confidence,
+            }
+        )
+
+    def test_missing_columns_raises(self):
+        with self.assertRaises(AssertionError):
+            select_good_units_relaxed_rp(pd.DataFrame({"bitwise_fail": [0]}))
+
+    def test_relaxed_threshold_admits_more_units_than_bitwise_fail(self):
+        # bit 0 (RP, legacy) fails on rows 1 and 2, but their v2 RP confidence is
+        # between the relaxed (70) and standard (90) thresholds -> only the strict
+        # bitwise_fail==0 selection excludes them.
+        df = self._df(
+            bitwise_fail=[0, 1, 1, 0b010, 0b100],
+            slidingRP2_max_confidence=[95.0, 80.0, 71.0, 95.0, 95.0],
+        )
+        relaxed = select_good_units_relaxed_rp(df, rp_confidence_threshold=70.0)
+        strict = (df["bitwise_fail"] == 0).to_numpy()
+        np.testing.assert_array_equal(relaxed, [True, True, True, False, False])
+        self.assertGreater(relaxed.sum(), strict.sum())
+
+    def test_noise_and_amp_vetoes_still_apply(self):
+        # bit 1 (noise_cutoff) and bit 2 (amp_median) failures are never overridden,
+        # regardless of a high slidingRP2_max_confidence.
+        df = self._df(
+            bitwise_fail=[0b010, 0b100, 0b110],
+            slidingRP2_max_confidence=[100.0, 100.0, 100.0],
+        )
+        relaxed = select_good_units_relaxed_rp(df)
+        np.testing.assert_array_equal(relaxed, [False, False, False])
+
+    def test_nan_confidence_treated_as_fail(self):
+        df = self._df(bitwise_fail=[0], slidingRP2_max_confidence=[np.nan])
+        relaxed = select_good_units_relaxed_rp(df)
+        self.assertFalse(relaxed[0])
+
+    def test_default_threshold_is_70(self):
+        df = self._df(bitwise_fail=[0, 0], slidingRP2_max_confidence=[69.9, 70.0])
+        relaxed = select_good_units_relaxed_rp(df)
+        np.testing.assert_array_equal(relaxed, [False, True])
 
 
 if __name__ == "__main__":

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -200,11 +200,11 @@ class TestCompute3DAcgs(unittest.TestCase):
 
 
 class TestSelectGoodUnitsRelaxedRp(unittest.TestCase):
-    def _df(self, bitwise_fail, slidingRP2_max_confidence):
+    def _df(self, bitwise_fail, max_confidence):
         return pd.DataFrame(
             {
                 "bitwise_fail": bitwise_fail,
-                "slidingRP2_max_confidence": slidingRP2_max_confidence,
+                "max_confidence": max_confidence,
             }
         )
 
@@ -213,35 +213,38 @@ class TestSelectGoodUnitsRelaxedRp(unittest.TestCase):
             select_good_units_relaxed_rp(pd.DataFrame({"bitwise_fail": [0]}))
 
     def test_relaxed_threshold_admits_more_units_than_bitwise_fail(self):
-        # bit 0 (RP, legacy) fails on rows 1 and 2, but their v2 RP confidence is
-        # between the relaxed (70) and standard (90) thresholds -> only the strict
-        # bitwise_fail==0 selection excludes them.
+        # bit 0 (RP) fails on rows 1 and 2 under the strict 90 threshold, but their
+        # max_confidence sits between the relaxed (70) and standard (90) thresholds ->
+        # only the strict bitwise_fail==0 selection excludes them.
         df = self._df(
             bitwise_fail=[0, 1, 1, 0b010, 0b100],
-            slidingRP2_max_confidence=[95.0, 80.0, 71.0, 95.0, 95.0],
+            max_confidence=[95.0, 80.0, 71.0, 95.0, 95.0],
         )
         relaxed = select_good_units_relaxed_rp(df, rp_confidence_threshold=70.0)
         strict = (df["bitwise_fail"] == 0).to_numpy()
         np.testing.assert_array_equal(relaxed, [True, True, True, False, False])
         self.assertGreater(relaxed.sum(), strict.sum())
+        # since both thresholds apply to the same max_confidence metric, relaxing
+        # can only add units, never drop one that was already strict-good.
+        self.assertTrue(np.all(relaxed[strict]))
 
     def test_noise_and_amp_vetoes_still_apply(self):
         # bit 1 (noise_cutoff) and bit 2 (amp_median) failures are never overridden,
-        # regardless of a high slidingRP2_max_confidence.
+        # regardless of a high max_confidence.
         df = self._df(
             bitwise_fail=[0b010, 0b100, 0b110],
-            slidingRP2_max_confidence=[100.0, 100.0, 100.0],
+            max_confidence=[100.0, 100.0, 100.0],
         )
         relaxed = select_good_units_relaxed_rp(df)
         np.testing.assert_array_equal(relaxed, [False, False, False])
 
     def test_nan_confidence_treated_as_fail(self):
-        df = self._df(bitwise_fail=[0], slidingRP2_max_confidence=[np.nan])
+        df = self._df(bitwise_fail=[0], max_confidence=[np.nan])
         relaxed = select_good_units_relaxed_rp(df)
         self.assertFalse(relaxed[0])
 
     def test_default_threshold_is_70(self):
-        df = self._df(bitwise_fail=[0, 0], slidingRP2_max_confidence=[69.9, 70.0])
+        df = self._df(bitwise_fail=[0, 0], max_confidence=[69.9, 70.0])
         relaxed = select_good_units_relaxed_rp(df)
         np.testing.assert_array_equal(relaxed, [False, True])
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -122,6 +122,12 @@ def _make_cluster_aggregates(path, n=10):
     return agg_path
 
 
+def _write_acg3d_files(agg_path, n=10):
+    """Write synthetic clusters.acgs_3d.npy and acgs_3d.times.npy into agg_path."""
+    np.save(agg_path / "clusters.acgs_3d.npy", np.zeros((n, 10, 201), dtype=np.float16))
+    np.save(agg_path / "acgs_3d.times.npy", np.linspace(-1000, 1000, 201))
+
+
 class TestProjectDataIO(unittest.TestCase):
     def setUp(self):
         self._tmpdir = tempfile.TemporaryDirectory()
@@ -149,6 +155,19 @@ class TestProjectDataIO(unittest.TestCase):
         # waveforms not present unless large_files=True was passed to download
         self.assertNotIn("waveforms", r)
         self.assertNotIn("df_waveforms", r)
+        # acgs_3d not present unless acg3d=True was passed to download
+        self.assertNotIn("acgs_3d", r)
+        self.assertNotIn("acgs_3d_times", r)
+
+    def test_read_cells_features_with_acgs_3d(self):
+        agg_path = self.project_path / "cells_aggregates"
+        _write_acg3d_files(agg_path, n=10)
+        r = ephysatlas.data.read_cells_features(self.project_path)
+        self.assertIn("acgs_3d", r)
+        self.assertEqual(r["acgs_3d"].shape, (10, 10, 201))
+        self.assertEqual(r["acgs_3d"].dtype, np.float16)
+        self.assertIn("acgs_3d_times", r)
+        self.assertEqual(r["acgs_3d_times"].shape, (201,))
 
     def test_read_cells_features_with_waveforms(self):
         n_traces = 50
@@ -201,7 +220,25 @@ class TestProjectDataIO(unittest.TestCase):
             len(ephysatlas.data._CELLS_AGGREGATES_FILES),
         )
         self.assertFalse(any("waveforms.voltage" in k for k in s3_keys))
+        self.assertFalse(any("acgs_3d" in k for k in s3_keys))
         self.assertTrue(all("cells_aggregates" in k for k in s3_keys))
+
+    def test_download_cells_features_acg3d(self):
+        mock_one = MagicMock()
+        mock_one.alyx = MagicMock()
+        with patch("ephysatlas.data.aws") as mock_aws:
+            mock_aws.get_s3_from_alyx.return_value = (MagicMock(), "test-bucket")
+            mock_aws.s3_download_file.return_value = Path("file1")
+            ephysatlas.data.download_cells_features(
+                self.tmp / "dl", project=self.project, one=mock_one, acg3d=True
+            )
+        s3_keys = [c[0][0] for c in mock_aws.s3_download_file.call_args_list]
+        n_expected = len(ephysatlas.data._CELLS_AGGREGATES_FILES) + len(
+            ephysatlas.data._ACG3D_FILES
+        )
+        self.assertEqual(mock_aws.s3_download_file.call_count, n_expected)
+        self.assertTrue(any("clusters.acgs_3d.npy" in k for k in s3_keys))
+        self.assertTrue(any("acgs_3d.times.npy" in k for k in s3_keys))
 
     def test_download_cells_features_large_files(self):
         mock_one = MagicMock()
@@ -238,6 +275,7 @@ class TestProjectDataIO(unittest.TestCase):
             one=mock_one,
             overwrite=False,
             large_files=False,
+            acg3d=False,
         )
         self.assertEqual(result, self.tmp / "dl" / self.project)
 


### PR DESCRIPTION
## Summary
- Adds `compute_3d_acgs` to `ephysatlas.cells`: firing-rate-decile x log-time-lag 3D autocorrelogram per cluster, matching Han Yu's NEMO/ICLR log-time resampling (vendored in `ephysatlas.iblnpyx`).
- Adds opt-in S3 download/read support in `ephysatlas.data` for the resulting cell aggregates (`clusters.acgs_3d.npy`, `acgs_3d.times.npy`), gated behind a new `acg3d=False` flag on `download_cells_features`/`download_project_data`, mirroring the existing `large_files` pattern for waveforms.
- `read_cells_features` picks up `acgs_3d`/`acgs_3d_times` only if the files exist locally (stay-mmap'd float16, ~3.5 GB array).
- Docs and tests updated accordingly.

Data itself is not yet on S3 — this PR only adds the code path. Local validation was done against a real aggregated dataset synced from SDSC (925,251 clusters, matching expected shapes), including spot-checking heatmaps of the 3D ACG for several good clusters across the firing-rate range.

## Test plan
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean
- [x] `pytest tests/test_data.py -v` — all pass
- [x] `pytest tests/ --ignore=tests/test_region_classifier.py -q` — full suite passes (that file has a known, pre-existing, unrelated segfault under the full suite; passes standalone)