### PR TITLE
Add probe_model/referencing_scheme to ModelProbeDetails and channel metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `rms_lf_no_car` LF feature: RMS of the LF band destriped without common-average referencing (`k_filter=None`), opt-in via `feature_params.lf.compute_rms_no_car` (default off).
 - `scale` parameter (default `True`) on `ephysatlas.features.csd`, surfaced through `CsdParams.scale`, controlling whether the CSD is scaled.
 - Published the Sphinx documentation to GitHub Pages via a `.github/workflows/documentation.yaml` Actions workflow (builds on pushes to `main` and pull requests; deploys from `main`).
+- `ModelProbeDetails` gains `probe_model` and `referencing_scheme` columns, populated from SpikeGLX meta-data via the new `ibl-neuropixel` `spikeglx.get_probe_model` / `spikeglx.get_referencing_scheme` (#82)
+- `SpikeGLXFileFeatureCalculator.enrich_channel_metadata` now broadcasts `probe_model` and `referencing_scheme` (from the AP/LF reader's SpikeGLX meta-data) onto every row of the channel metadata (#82)
 
 ### Changed
 - Channel metadata is now merged onto the feature table on the physical recording site `(axial_um, lateral_um, shank)` (rounded to the nearest micrometre) instead of on `channel` / `rawInd`, whose numbering is unreliable across data sources. `rawInd` is carried as descriptive metadata only. Channel builders now always provide `shank`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `scale` parameter (default `True`) on `ephysatlas.features.csd`, surfaced through `CsdParams.scale`, controlling whether the CSD is scaled.
 - Published the Sphinx documentation to GitHub Pages via a `.github/workflows/documentation.yaml` Actions workflow (builds on pushes to `main` and pull requests; deploys from `main`).
 - `ModelProbeDetails` gains `probe_model` and `referencing_scheme` columns, populated from SpikeGLX meta-data via the new `ibl-neuropixel` `spikeglx.get_probe_model` / `spikeglx.get_referencing_scheme` (#82)
-- `SpikeGLXFileFeatureCalculator.enrich_channel_metadata` now broadcasts `probe_model` and `referencing_scheme` (from the AP/LF reader's SpikeGLX meta-data) onto every row of the channel metadata (#82)
+- `enrich_channel_metadata` now broadcasts `probe_model` and `referencing_scheme` onto every row of the channel metadata for both SpikeGLX-backed sources (`SpikeGLXFileFeatureCalculator` and `IBLPIDFeatureCalculator`), read from the first reader (AP, then LF) carrying SpikeGLX meta-data (#82)
 
 ### Changed
 - Channel metadata is now merged onto the feature table on the physical recording site `(axial_um, lateral_um, shank)` (rounded to the nearest micrometre) instead of on `channel` / `rawInd`, whose numbering is unreliable across data sources. `rawInd` is carried as descriptive metadata only. Channel builders now always provide `shank`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dynamic = ["version"]
 # by ibl-neuropixel, which is fine; the dartsort spike path is the part gated by [full].)
 dependencies = [
     "ibllib>=3.3.1",          # brainbox, ibllib.pipes, ONE-api (one.api/one.remote.aws), iblutil
-    "ibl-neuropixel>=1.11.0", # ibldsp, neuropixel, spikeglx
+    "ibl-neuropixel>=1.12.0", # ibldsp, neuropixel, spikeglx
     "lfpack>=0.2.0",          # data.py read_lfp_features() lazy import (LFPackReader)
     "iblatlas",               # iblatlas.atlas/regions/genomics
     "xgboost>=3.0.1",         # regionclassifier (top-level import)

--- a/src/ephysatlas/feature_calculators/ibl.py
+++ b/src/ephysatlas/feature_calculators/ibl.py
@@ -128,19 +128,21 @@ class IBLPIDFeatureCalculator(SpikeGlxLikeFeatureCalculator):
     def enrich_channel_metadata(
         self, channels: pd.DataFrame, options: FeatureComputationOptions
     ) -> pd.DataFrame:
-        """Add optional target coordinates from Alyx trajectories.
+        """Add probe metadata and optional target coordinates from Alyx trajectories.
 
         Args:
             channels (pd.DataFrame): Channel metadata.
             options (FeatureComputationOptions): Current computation options.
 
         Returns:
-            pd.DataFrame: Channel metadata with optional ``x_target``,
+            pd.DataFrame: Channel metadata with ``probe_model`` and
+            ``referencing_scheme`` columns, plus optional ``x_target``,
             ``y_target``, and ``z_target`` columns.
 
         Raises:
             ValueError: If trajectory metadata are required but cannot be loaded.
         """
+        channels = self._join_probe_metadata(channels)
         if not options.include_trajectory:
             return channels
         required = {"x_target", "y_target", "z_target"}

--- a/src/ephysatlas/feature_calculators/spikeglx.py
+++ b/src/ephysatlas/feature_calculators/spikeglx.py
@@ -18,7 +18,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-import spikeglx
 
 from ephysatlas.feature_computation import add_target_coordinates
 
@@ -132,25 +131,3 @@ class SpikeGLXFileFeatureCalculator(SpikeGlxLikeFeatureCalculator):
             channels=channel_dict, traj_dict=self.traj_dict
         )
         return pd.DataFrame(enriched)
-
-    def _join_probe_metadata(self, channels: pd.DataFrame) -> pd.DataFrame:
-        """Broadcast probe-level metadata onto every channel.
-
-        Args:
-            channels (pd.DataFrame): Channel metadata.
-
-        Returns:
-            pd.DataFrame: `channels` with `probe_model` and
-            `referencing_scheme` columns, read from the AP (or LF, if AP is
-            unavailable) SpikeGLX meta-data. Both are None if no reader has
-            meta-data (e.g. a reader opened without a companion .meta file).
-        """
-        reader = self.sr_ap if self.sr_ap is not None else self.sr_lf
-        meta = getattr(reader, "meta", None)
-        channels["probe_model"] = (
-            spikeglx.get_probe_model(meta) if meta is not None else None
-        )
-        channels["referencing_scheme"] = (
-            spikeglx.get_referencing_scheme(meta) if meta is not None else None
-        )
-        return channels

--- a/src/ephysatlas/feature_calculators/spikeglx.py
+++ b/src/ephysatlas/feature_calculators/spikeglx.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import spikeglx
 
 from ephysatlas.feature_computation import add_target_coordinates
 
@@ -103,19 +104,21 @@ class SpikeGLXFileFeatureCalculator(SpikeGlxLikeFeatureCalculator):
     def enrich_channel_metadata(
         self, channels: pd.DataFrame, options: FeatureComputationOptions
     ) -> pd.DataFrame:
-        """Add optional trajectory target coordinates for local file sources.
+        """Add probe metadata and optional trajectory target coordinates.
 
         Args:
             channels (pd.DataFrame): Channel metadata.
             options (FeatureComputationOptions): Current computation options.
 
         Returns:
-            pd.DataFrame: Channel metadata with optional ``x_target``,
+            pd.DataFrame: Channel metadata with ``probe_model`` and
+            ``referencing_scheme`` columns, plus optional ``x_target``,
             ``y_target``, and ``z_target`` columns.
 
         Raises:
             ValueError: If trajectory metadata are required but missing.
         """
+        channels = self._join_probe_metadata(channels)
         if not options.include_trajectory:
             return channels
         if self.traj_dict is None:
@@ -129,3 +132,25 @@ class SpikeGLXFileFeatureCalculator(SpikeGlxLikeFeatureCalculator):
             channels=channel_dict, traj_dict=self.traj_dict
         )
         return pd.DataFrame(enriched)
+
+    def _join_probe_metadata(self, channels: pd.DataFrame) -> pd.DataFrame:
+        """Broadcast probe-level metadata onto every channel.
+
+        Args:
+            channels (pd.DataFrame): Channel metadata.
+
+        Returns:
+            pd.DataFrame: `channels` with `probe_model` and
+            `referencing_scheme` columns, read from the AP (or LF, if AP is
+            unavailable) SpikeGLX meta-data. Both are None if no reader has
+            meta-data (e.g. a reader opened without a companion .meta file).
+        """
+        reader = self.sr_ap if self.sr_ap is not None else self.sr_lf
+        meta = getattr(reader, "meta", None)
+        channels["probe_model"] = (
+            spikeglx.get_probe_model(meta) if meta is not None else None
+        )
+        channels["referencing_scheme"] = (
+            spikeglx.get_referencing_scheme(meta) if meta is not None else None
+        )
+        return channels

--- a/src/ephysatlas/feature_calculators/spikeglx_like.py
+++ b/src/ephysatlas/feature_calculators/spikeglx_like.py
@@ -82,6 +82,44 @@ class SpikeGlxLikeFeatureCalculator(BaseFeatureCalculator):
             self._sr_lf = self._open_reader("lf")
         return self._sr_lf
 
+    def _join_probe_metadata(self, channels: pd.DataFrame) -> pd.DataFrame:
+        """Broadcast probe-level SpikeGLX metadata onto every channel.
+
+        Args:
+            channels (pd.DataFrame): Channel metadata.
+
+        Returns:
+            pd.DataFrame: A copy of ``channels`` with ``probe_model`` and
+            ``referencing_scheme`` columns, taken from the AP reader's SpikeGLX
+            meta-data, falling back to the already-open LF reader. Both are
+            ``pd.NA`` when neither carries meta-data (e.g. a reader opened
+            without a companion .meta file).
+        """
+        import spikeglx
+
+        # An AP reader can exist but carry no meta-data (no companion .meta file),
+        # in which case LF can still supply it. The fallback reads the *already
+        # opened* LF reader rather than the ``sr_lf`` property: opening a reader
+        # costs an Alyx round-trip for streamed sources, and load_raw_snippet()
+        # has opened both bands by the time this runs in the compute pipeline.
+        meta = getattr(self.sr_ap, "meta", None)
+        if meta is None:
+            meta = getattr(self._sr_lf, "meta", None)
+
+        probe_model = spikeglx.get_probe_model(meta) if meta is not None else pd.NA
+        referencing = (
+            spikeglx.get_referencing_scheme(meta) if meta is not None else pd.NA
+        )
+        # The explicit "string" dtype keeps an all-NA
+        # column concat-compatible with a populated one when channel tables from
+        # several probes are aggregated.
+        return channels.assign(
+            probe_model=pd.Series(probe_model, index=channels.index, dtype="string"),
+            referencing_scheme=pd.Series(
+                referencing, index=channels.index, dtype="string"
+            ),
+        )
+
     def load_raw_snippet(self, window: SnippetWindow) -> RawSnippet:
         """Read AP/LF snippets from the spikeglx-like readers.
 

--- a/src/ephysatlas/features.py
+++ b/src/ephysatlas/features.py
@@ -755,6 +755,16 @@ class ModelProbeDetails(pa.DataFrameModel):
     probe_name: Optional[str] = pa.Field(nullable=True)
     probe_serial: Optional[str] = pa.Field(nullable=True)
     neuropixel_version: Optional[str] = pa.Field(nullable=True)
+    probe_model: Optional[str] = pa.Field(
+        nullable=True,
+        description="Probe part number from SpikeGLX meta-data (imDatPrb_pn), "
+        "e.g. 'NP2013'. See spikeglx.get_probe_model.",
+    )
+    referencing_scheme: Optional[str] = pa.Field(
+        nullable=True,
+        description="Referencing scheme from SpikeGLX meta-data (imroTbl): "
+        "'external', 'tip', 'ground' or 'on_shank'. See spikeglx.get_referencing_scheme.",
+    )
     lab: Optional[str] = pa.Field(nullable=True)
     pname: Optional[str] = pa.Field(nullable=True)
     spike_sorting: Optional[str] = pa.Field(nullable=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -147,6 +147,17 @@ class TestProjectDataIO(unittest.TestCase):
         self.assertIn("pid", df.columns)
         self.assertIn("bwm", df.columns)
 
+    def test_read_probe_details_accepts_file_without_optional_columns(self):
+        # Files written before probe_model/referencing_scheme were added to
+        # ModelProbeDetails must still validate: the schema marks them Optional,
+        # so strict validation may not require their presence.
+        df = _make_probe_details()
+        legacy = df.drop(columns=["probe_model", "referencing_scheme"])
+        legacy.to_parquet(self.project_path / "df_probe_details.pqt")
+        out = ephysatlas.data.read_probe_details(self.project_path, strict=True)
+        self.assertNotIn("probe_model", out.columns)
+        self.assertEqual(out.shape[0], 3)
+
     def test_read_cells_features(self):
         r = ephysatlas.data.read_cells_features(self.project_path)
         self.assertEqual(r["df_clusters"].shape[0], 10)

--- a/tests/test_ibl_feature_calculator.py
+++ b/tests/test_ibl_feature_calculator.py
@@ -14,7 +14,10 @@ import numpy as np
 import pandas as pd
 
 from ephysatlas.feature_calculators.ibl import IBLPIDFeatureCalculator
-from ephysatlas.feature_calculators.types import RawSnippet
+from ephysatlas.feature_calculators.types import (
+    FeatureComputationOptions,
+    RawSnippet,
+)
 
 PID = "test_pid"
 N_CH = 4
@@ -23,6 +26,14 @@ FS_AP = 30000.0
 
 # Deterministic synthetic AP data shaped (n_total_channels, n_samples).
 AP_DATA = np.arange((N_CH + NSYNC) * 4000, dtype=np.float32).reshape(N_CH + NSYNC, 4000)
+
+
+# NP2.0 four-shank meta-data; the first imroTbl entry has reference id 0 -> "external".
+_META_NP2013 = {
+    "imDatPrb_pn": "NP2013",
+    "imDatPrb_type": 2013.0,
+    "imroTbl": "(2013,384)(0 0 0 0 0)(1 0 0 0 1)(2 0 0 0 2)(3 0 0 0 3)",
+}
 
 
 def _geometry() -> dict:
@@ -203,6 +214,35 @@ class TestIBLFeatureCalculator(unittest.TestCase):
         features = pd.DataFrame({"feat": [1.0, 2.0]})  # no 'channel' column
         with self.assertRaises(ValueError):
             calc._attach_physical_coordinates(features, _geometry())
+
+    def test_enrich_adds_probe_metadata(self):
+        # The streamed IBL reader carries SpikeGLX meta-data too, so channels.pqt
+        # from this source must gain the same two columns as the file-based source.
+        calc = IBLPIDFeatureCalculator(pid=PID, one=mock.MagicMock())
+        reader = _FakeReader(AP_DATA, FS_AP)
+        reader.meta = _META_NP2013
+        calc._sr_ap = reader
+        out = calc.enrich_channel_metadata(
+            pd.DataFrame({"channel": np.arange(N_CH)}),
+            FeatureComputationOptions(include_trajectory=False),
+        )
+        self.assertTrue((out["probe_model"] == "NP2013").all())
+        self.assertTrue((out["referencing_scheme"] == "external").all())
+
+    def test_enrich_probe_metadata_na_without_reader_meta(self):
+        # _FakeReader has no ``meta`` attribute at all, standing in for a reader
+        # opened without SpikeGLX meta-data. This also pins the "never open a
+        # reader just to read meta-data" contract: no LF reader is set, so a
+        # fallback through the ``sr_lf`` property would construct a real
+        # SpikeSortingLoader against the mock ONE and blow up.
+        calc = IBLPIDFeatureCalculator(pid=PID, one=mock.MagicMock())
+        calc._sr_ap = _FakeReader(AP_DATA, FS_AP)
+        out = calc.enrich_channel_metadata(
+            pd.DataFrame({"channel": np.arange(N_CH)}),
+            FeatureComputationOptions(include_trajectory=False),
+        )
+        self.assertTrue(out["probe_model"].isna().all())
+        self.assertTrue(out["referencing_scheme"].isna().all())
 
 
 if __name__ == "__main__":

--- a/tests/test_spikeglx_feature_calculator.py
+++ b/tests/test_spikeglx_feature_calculator.py
@@ -32,16 +32,24 @@ def _geometry() -> dict:
     }
 
 
+_META_NP2013 = {
+    "imDatPrb_pn": "NP2013",
+    "imDatPrb_type": 2013.0,
+    "imroTbl": "(2013,384)(0 0 0 0 0)(1 0 0 0 1)(2 0 0 0 2)(3 0 0 0 3)",
+}
+
+
 class _FakeReader:
     """Minimal ``spikeglx.Reader``-like stub."""
 
-    def __init__(self, geometry=None):
+    def __init__(self, geometry=None, meta=None):
         self.fs = FS_AP
         self.ns = 6000
         self.nc = N_CH + NSYNC
         self.nsync = NSYNC
         self.file_bin = None
         self.geometry = geometry if geometry is not None else _geometry()
+        self.meta = meta
 
 
 def _channels() -> pd.DataFrame:
@@ -85,14 +93,18 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
 
     def test_enrich_skipped_when_not_included(self):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
+        calc._sr_ap = _FakeReader(meta=_META_NP2013)
         channels = _channels()
         out = calc.enrich_channel_metadata(
             channels, FeatureComputationOptions(include_trajectory=False)
         )
         self.assertIs(out, channels)
+        self.assertEqual((out["probe_model"] == "NP2013").all(), True)
+        self.assertEqual((out["referencing_scheme"] == "external").all(), True)
 
     def test_enrich_returns_unchanged_when_traj_missing_and_not_required(self):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
+        calc._sr_ap = _FakeReader(meta=_META_NP2013)
         channels = _channels()
         out = calc.enrich_channel_metadata(
             channels,
@@ -104,6 +116,7 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
 
     def test_enrich_raises_when_traj_required_but_missing(self):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
+        calc._sr_ap = _FakeReader(meta=_META_NP2013)
         with self.assertRaises(ValueError):
             calc.enrich_channel_metadata(
                 _channels(),
@@ -115,6 +128,7 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
     def test_enrich_with_traj_dict_calls_add_target_coordinates(self):
         traj = {"x": 0.0, "y": 0.0, "z": 0.0, "depth": 0.0, "theta": 0.0, "phi": 0.0}
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=traj)
+        calc._sr_ap = _FakeReader(meta=_META_NP2013)
         channels = _channels()
 
         def _fake_add(channels=None, traj_dict=None):
@@ -135,6 +149,15 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
         self.assertEqual(m.call_args.kwargs["traj_dict"], traj)
         for col in ("x_target", "y_target", "z_target"):
             self.assertIn(col, out.columns)
+
+    def test_enrich_probe_metadata_none_without_reader_meta(self):
+        calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
+        calc._sr_ap = _FakeReader(meta=None)
+        out = calc.enrich_channel_metadata(
+            _channels(), FeatureComputationOptions(include_trajectory=False)
+        )
+        self.assertTrue(out["probe_model"].isna().all())
+        self.assertTrue(out["referencing_scheme"].isna().all())
 
 
 if __name__ == "__main__":

--- a/tests/test_spikeglx_feature_calculator.py
+++ b/tests/test_spikeglx_feature_calculator.py
@@ -91,28 +91,41 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
         np.testing.assert_array_equal(metadata["lateral_um"], _geometry()["x"])
         np.testing.assert_array_equal(metadata["shank"], _geometry()["shank"])
 
-    def test_enrich_skipped_when_not_included(self):
+    def test_enrich_adds_probe_metadata_when_trajectory_not_included(self):
+        calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
+        calc._sr_ap = _FakeReader(meta=_META_NP2013)
+        out = calc.enrich_channel_metadata(
+            _channels(), FeatureComputationOptions(include_trajectory=False)
+        )
+        self.assertTrue((out["probe_model"] == "NP2013").all())
+        self.assertTrue((out["referencing_scheme"] == "external").all())
+
+    def test_enrich_does_not_mutate_the_input_frame(self):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
         calc._sr_ap = _FakeReader(meta=_META_NP2013)
         channels = _channels()
         out = calc.enrich_channel_metadata(
             channels, FeatureComputationOptions(include_trajectory=False)
         )
-        self.assertIs(out, channels)
-        self.assertEqual((out["probe_model"] == "NP2013").all(), True)
-        self.assertEqual((out["referencing_scheme"] == "external").all(), True)
+        self.assertIsNot(out, channels)
+        self.assertNotIn("probe_model", channels.columns)
+        self.assertNotIn("referencing_scheme", channels.columns)
 
-    def test_enrich_returns_unchanged_when_traj_missing_and_not_required(self):
+    def test_enrich_returns_probe_metadata_only_when_traj_missing_and_not_required(
+        self,
+    ):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
         calc._sr_ap = _FakeReader(meta=_META_NP2013)
-        channels = _channels()
         out = calc.enrich_channel_metadata(
-            channels,
+            _channels(),
             FeatureComputationOptions(
                 include_trajectory=True, require_trajectory=False
             ),
         )
-        self.assertIs(out, channels)
+        self.assertTrue((out["probe_model"] == "NP2013").all())
+        # Trajectory enrichment was skipped, so no target coordinates were added.
+        for col in ("x_target", "y_target", "z_target"):
+            self.assertNotIn(col, out.columns)
 
     def test_enrich_raises_when_traj_required_but_missing(self):
         calc = SpikeGLXFileFeatureCalculator(ap_file="probe.ap.bin", traj_dict=None)
@@ -158,6 +171,29 @@ class TestSpikeGLXFileFeatureCalculator(unittest.TestCase):
         )
         self.assertTrue(out["probe_model"].isna().all())
         self.assertTrue(out["referencing_scheme"].isna().all())
+
+    def test_enrich_probe_metadata_falls_back_to_lf_when_ap_meta_missing(self):
+        # An AP reader without a companion .meta file must not shadow the LF
+        # reader's meta-data.
+        calc = SpikeGLXFileFeatureCalculator(
+            ap_file="probe.ap.bin", lf_file="probe.lf.bin", traj_dict=None
+        )
+        calc._sr_ap = _FakeReader(meta=None)
+        calc._sr_lf = _FakeReader(meta=_META_NP2013)
+        out = calc.enrich_channel_metadata(
+            _channels(), FeatureComputationOptions(include_trajectory=False)
+        )
+        self.assertTrue((out["probe_model"] == "NP2013").all())
+        self.assertTrue((out["referencing_scheme"] == "external").all())
+
+    def test_enrich_probe_metadata_from_lf_only_calculator(self):
+        calc = SpikeGLXFileFeatureCalculator(lf_file="probe.lf.bin", traj_dict=None)
+        calc._sr_lf = _FakeReader(meta=_META_NP2013)
+        out = calc.enrich_channel_metadata(
+            _channels(), FeatureComputationOptions(include_trajectory=False)
+        )
+        self.assertTrue((out["probe_model"] == "NP2013").all())
+        self.assertTrue((out["referencing_scheme"] == "external").all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `ModelProbeDetails` gains `probe_model` and `referencing_scheme` columns (`df_probe_details.pqt`), sourced from SpikeGLX meta-data via the new `ibl-neuropixel` `spikeglx.get_probe_model` / `spikeglx.get_referencing_scheme` ([ibl-neuropixel#92](https://github.com/int-brain-lab/ibl-neuropixel/pull/92), not yet released).
- `SpikeGLXFileFeatureCalculator.enrich_channel_metadata` now broadcasts the same two columns onto the per-channel metadata, read from the AP (or LF) reader's meta-data.
- Closes #82

## Note
- `pyproject.toml` still pins `ibl-neuropixel>=1.11.0`; needs bumping once `ibl-neuropixel` is released with the new `spikeglx` functions.

## Test plan
- [x] `pytest tests/test_data.py tests/test_spikeglx_feature_calculator.py` — all pass
- [x] `pytest tests/` (excluding one pre-existing, unrelated segfault in `test_region_classifier.py::TestModelIO::test_read_after_write`) — 159 passed, 10 skipped