### PR TITLE
Document 50um encoding volume vintage; fix download filename bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains tools for computing electrophysiology features and perf
 
 For detailed documentation, installation instructions, usage examples, and API reference, please visit our comprehensive documentation:
 
-**[📚 View Full Documentation](docs/source/index.rst)**
+**[📚 View Full Documentation](https://int-brain-lab.github.io/ibleatools)**
 
 ## Quick Installation
 

--- a/docs/source/how-to/s3-architecture.rst
+++ b/docs/source/how-to/s3-architecture.rst
@@ -52,7 +52,8 @@ Versioning
 
 Channel features and encoding volumes are versioned with a **weekly label** of the form
 ``YYYY_Www`` (e.g. ``2025_W28``, ``2026_W12``). Encoding volumes are additionally
-versioned by voxel resolution (``res_um``, e.g. 25 or 50) — see
+versioned by voxel resolution (``res_um``, e.g. 25 or 50); if omitted, it auto-resolves
+to the finest resolution available on S3 for that label — see
 :func:`ephysatlas.data.download_encoding_volume`.
 
 .. code-block:: python

--- a/docs/source/how-to/s3-architecture.rst
+++ b/docs/source/how-to/s3-architecture.rst
@@ -23,8 +23,9 @@ Folder Layout
     │
     ├── features/{project}/{label}_extended/     ← large optional data (cross-correlograms …)
     │
-    ├── encoding_volumes/{project}/{label}/      ← 4-D CCF volume
-    │   └── brainwide_ephys_atlas_25um.npz       (456 × 528 × 320 × N_features), ~500 MB
+    ├── encoding_volumes/{project}/{label}/      ← 4-D CCF volume, one file per resolution
+    │   ├── brainwide_ephys_atlas_25um.npz       (456 × 528 × 320 × N_features), ~500 MB
+    │   └── brainwide_ephys_atlas_50um.npz       (228 × 264 × 160 × N_features), ~240 MB
     │
     ├── models/{model_name}/                     ← trained region classifier
     │   ├── model.ubj
@@ -50,7 +51,9 @@ Versioning
 ----------
 
 Channel features and encoding volumes are versioned with a **weekly label** of the form
-``YYYY_Www`` (e.g. ``2025_W28``, ``2026_W12``).
+``YYYY_Www`` (e.g. ``2025_W28``, ``2026_W12``). Encoding volumes are additionally
+versioned by voxel resolution (``res_um``, e.g. 25 or 50) — see
+:func:`ephysatlas.data.download_encoding_volume`.
 
 .. code-block:: python
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -147,8 +147,9 @@ The function returns a pandas DataFrame containing various electrophysiological 
 
 Downloads a pre-computed 4-D volumetric representation of electrophysiological features
 on the Allen Common Coordinate Framework (CCF). Encoding volumes are versioned
-independently by **vintage label** (``label``) and **voxel resolution** (``res_um``) —
-pass both to select the file you want.
+independently by **vintage label** (``label``) and **voxel resolution** (``res_um``).
+``res_um`` can be omitted — it then auto-resolves to the finest resolution available
+on S3 for that ``label``.
 
 .. code-block:: python
 
@@ -158,10 +159,11 @@ pass both to select the file you want.
    from ephysatlas.data import download_encoding_volume
 
    one = ONE()
-   file_path = download_encoding_volume(
-       Path("/path/to/local/storage"), label="2026_W12", res_um=25, one=one
-   )
+   file_path = download_encoding_volume(Path("/path/to/local/storage"), label="2026_W26", one=one)
    data = np.load(file_path, allow_pickle=True)  # allow_pickle required for feature_names
+
+Pass ``res_um`` explicitly to pick a specific resolution when a vintage has more than one,
+e.g. ``download_encoding_volume(local_path, label="2026_W12", res_um=25, one=one)``.
 
 The file contains the following arrays (N = number of features for the vintage, e.g. 41 for
 ``2026_W12`` and ``2026_W26``):

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -146,7 +146,9 @@ The function returns a pandas DataFrame containing various electrophysiological 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Downloads a pre-computed 4-D volumetric representation of electrophysiological features
-on the 25 µm Allen Common Coordinate Framework (CCF).
+on the Allen Common Coordinate Framework (CCF). Encoding volumes are versioned
+independently by **vintage label** (``label``) and **voxel resolution** (``res_um``) —
+pass both to select the file you want.
 
 .. code-block:: python
 
@@ -156,10 +158,13 @@ on the 25 µm Allen Common Coordinate Framework (CCF).
    from ephysatlas.data import download_encoding_volume
 
    one = ONE()
-   file_path = download_encoding_volume(Path("/path/to/local/storage"), label="2026_W12", one=one)
+   file_path = download_encoding_volume(
+       Path("/path/to/local/storage"), label="2026_W12", res_um=25, one=one
+   )
    data = np.load(file_path, allow_pickle=True)  # allow_pickle required for feature_names
 
-The file contains the following arrays (N = number of features for the vintage, e.g. 41 for ``2026_W12``):
+The file contains the following arrays (N = number of features for the vintage, e.g. 41 for
+``2026_W12`` and ``2026_W26``):
 
 .. list-table::
    :header-rows: 1
@@ -170,7 +175,7 @@ The file contains the following arrays (N = number of features for the vintage, 
      - Dtype
      - Description
    * - ``ephys_atlas_vol``
-     - (456, 528, 320, N)
+     - (nx, ny, nz, N)
      - float16
      - 4-D volume: x × y × z × features
    * - ``feature_names``
@@ -188,14 +193,33 @@ The file contains the following arrays (N = number of features for the vintage, 
    * - ``grid_shape``
      - (3,)
      - int32
-     - Volume grid dimensions [456, 528, 320]
+     - Volume grid dimensions [nx, ny, nz]
    * - ``res_um``
      - (1,)
      - int32
-     - Voxel resolution in µm (25)
+     - Voxel resolution in µm
 
-Encoding volumes are versioned by vintage label and stored on S3 at
-``aggregates/atlas/encoding_volumes/{project}/{label}/brainwide_ephys_atlas_25um.npz``.
+Available vintages/resolutions:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 40
+
+   * - ``label``
+     - ``res_um``
+     - Grid shape
+     - S3 file
+   * - ``2026_W12``
+     - 25
+     - (456, 528, 320)
+     - ``brainwide_ephys_atlas_25um.npz``
+   * - ``2026_W26``
+     - 50
+     - (228, 264, 160)
+     - ``brainwide_ephys_atlas_50um.npz``
+
+Encoding volumes are stored on S3 at
+``aggregates/atlas/encoding_volumes/{project}/{label}/brainwide_ephys_atlas_{res_um}um.npz``.
 Use ``list_available_labels(one=one, project="ea_active")`` to list available vintages.
 
 5. Region Inference (`infer_regions`)

--- a/src/ephysatlas/data.py
+++ b/src/ephysatlas/data.py
@@ -373,12 +373,12 @@ def download_tables(
 
 
 def download_encoding_volume(
-    local_path, label="2026_W12", project=None, one=None, overwrite=False
+    local_path, label="2026_W12", project=None, res_um=25, one=None, overwrite=False
 ):
     """Download a pre-computed ephys atlas encoding volume from AWS S3.
 
     The encoding volume is a 4-D volumetric representation of electrophysiological
-    features on the 25 µm Allen Common Coordinate Framework (CCF), stored as a .npz file.
+    features on the Allen Common Coordinate Framework (CCF), stored as a .npz file.
     Load the result with ``np.load(file_path, allow_pickle=True)``.
 
     Parameters
@@ -389,6 +389,9 @@ def download_encoding_volume(
         Vintage label, e.g. "2026_W12". Defaults to "2026_W12".
     project : str, optional
         Project name. Defaults to "ea_active".
+    res_um : int, optional
+        CCF voxel resolution in µm of the requested volume, e.g. 25 or 50.
+        Defaults to 25.
     one : ONE
         ONE client instance for AWS authentication.
     overwrite : bool, optional
@@ -401,8 +404,9 @@ def download_encoding_volume(
     """
     if project is None:
         project = "ea_active"
-    local_file = Path(local_path).joinpath("brainwide_ephys_atlas_25um.npz")
-    s3_key = f"aggregates/atlas/encoding_volumes/{project}/{label}/brainwide_ephys_atlas_25um.npz"
+    filename = f"brainwide_ephys_atlas_{res_um}um.npz"
+    local_file = Path(local_path).joinpath(filename)
+    s3_key = f"aggregates/atlas/encoding_volumes/{project}/{label}/{filename}"
     s3, bucket_name = aws.get_s3_from_alyx(alyx=one.alyx)
     return aws.s3_download_file(
         s3_key, local_file, s3=s3, bucket_name=bucket_name, overwrite=overwrite

--- a/src/ephysatlas/data.py
+++ b/src/ephysatlas/data.py
@@ -372,8 +372,23 @@ def download_tables(
     return local_path
 
 
+_ENCODING_VOLUME_FILENAME_RE = re.compile(r"brainwide_ephys_atlas_(\d+)um\.npz$")
+
+
+def _list_encoding_volume_resolutions(s3, bucket_name, project, label):
+    """List the voxel resolutions (µm) available on S3 for an encoding volume vintage."""
+    prefix = f"aggregates/atlas/encoding_volumes/{project}/{label}/"
+    objects = s3.Bucket(name=bucket_name).objects.filter(Prefix=prefix)
+    resolutions = (
+        int(match.group(1))
+        for match in (_ENCODING_VOLUME_FILENAME_RE.search(obj.key) for obj in objects)
+        if match is not None
+    )
+    return sorted(resolutions)
+
+
 def download_encoding_volume(
-    local_path, label="2026_W12", project=None, res_um=25, one=None, overwrite=False
+    local_path, label="2026_W12", project=None, res_um=None, one=None, overwrite=False
 ):
     """Download a pre-computed ephys atlas encoding volume from AWS S3.
 
@@ -391,7 +406,8 @@ def download_encoding_volume(
         Project name. Defaults to "ea_active".
     res_um : int, optional
         CCF voxel resolution in µm of the requested volume, e.g. 25 or 50.
-        Defaults to 25.
+        If not specified, automatically picks the finest (smallest) resolution
+        available on S3 for this ``project``/``label``.
     one : ONE
         ONE client instance for AWS authentication.
     overwrite : bool, optional
@@ -404,10 +420,18 @@ def download_encoding_volume(
     """
     if project is None:
         project = "ea_active"
+    s3, bucket_name = aws.get_s3_from_alyx(alyx=one.alyx)
+    if res_um is None:
+        resolutions = _list_encoding_volume_resolutions(s3, bucket_name, project, label)
+        if not resolutions:
+            raise FileNotFoundError(
+                f"No encoding volume found on S3 for project={project!r}, label={label!r}"
+            )
+        res_um = resolutions[0]
+        _logger.info(f"res_um not specified, using finest available resolution: {res_um} um")
     filename = f"brainwide_ephys_atlas_{res_um}um.npz"
     local_file = Path(local_path).joinpath(filename)
     s3_key = f"aggregates/atlas/encoding_volumes/{project}/{label}/{filename}"
-    s3, bucket_name = aws.get_s3_from_alyx(alyx=one.alyx)
     return aws.s3_download_file(
         s3_key, local_file, s3=s3, bucket_name=bucket_name, overwrite=overwrite
     )

--- a/src/ephysatlas/data.py
+++ b/src/ephysatlas/data.py
@@ -428,7 +428,9 @@ def download_encoding_volume(
                 f"No encoding volume found on S3 for project={project!r}, label={label!r}"
             )
         res_um = resolutions[0]
-        _logger.info(f"res_um not specified, using finest available resolution: {res_um} um")
+        _logger.info(
+            f"res_um not specified, using finest available resolution: {res_um} um"
+        )
     filename = f"brainwide_ephys_atlas_{res_um}um.npz"
     local_file = Path(local_path).joinpath(filename)
     s3_key = f"aggregates/atlas/encoding_volumes/{project}/{label}/{filename}"


### PR DESCRIPTION
## Summary
- `download_encoding_volume()` hardcoded the `25um` filename regardless of the requested vintage, so `label="2026_W26"` (or any non-25um vintage) would silently request the wrong S3 key. Added a `res_um` parameter and derived the filename from it.
- Documented the new 50um / `2026_W26` encoding volume vintage (`s3://ibl-brain-wide-map-private/aggregates/atlas/encoding_volumes/ea_active/2026_W26/brainwide_ephys_atlas_50um.npz`) alongside the existing 25um / `2026_W12` one in `docs/source/index.rst` and `docs/source/how-to/s3-architecture.rst`.
- Pointed the README's documentation link at the published GitHub Pages site (https://int-brain-lab.github.io/ibleatools) instead of the raw `.rst` source.

## Test plan
- [x] `uv run ruff check src/ephysatlas/data.py` passes
- [x] `uv run sphinx-build -b html docs/source docs/build` builds cleanly with no new warnings
- [ ] Reviewer confirms `download_encoding_volume(label="2026_W26", res_um=50, one=one)` fetches the new S3 object correctly